### PR TITLE
Fix doctrine mapping

### DIFF
--- a/DependencyInjection/SonataArticleExtension.php
+++ b/DependencyInjection/SonataArticleExtension.php
@@ -99,65 +99,74 @@ final class SonataArticleExtension extends Extension
                 'position' => 'ASC',
             ),
         ));
-        $collector->addAssociation($config['class']['article'], 'mapManyToMany', array(
-            'fieldName' => 'categories',
-            'targetEntity' => $config['class']['category'],
-            'cascade' => array(),
-            'joinTable' => array(
-                'name' => 'article__article_categories',
+
+        if (class_exists($config['class']['category'])) {
+            $collector->addAssociation($config['class']['article'], 'mapManyToMany', array(
+                'fieldName' => 'categories',
+                'targetEntity' => $config['class']['category'],
+                'cascade' => array(),
+                'joinTable' => array(
+                    'name' => 'article__article_categories',
+                    'joinColumns' => array(
+                        array(
+                            'name' => 'article_id',
+                            'referencedColumnName' => 'id',
+                            'onDelete' => 'CASCADE',
+                        ),
+                    ),
+                    'inverseJoinColumns' => array(
+                        array(
+                            'name' => 'category_id',
+                            'referencedColumnName' => 'id',
+                            'onDelete' => 'CASCADE',
+                        ),
+                    ),
+                ),
+            ));
+        }
+
+        if (class_exists($config['class']['tag'])) {
+            $collector->addAssociation($config['class']['article'], 'mapManyToMany', array(
+                'fieldName' => 'tags',
+                'targetEntity' => $config['class']['tag'],
+                'cascade' => array(),
+                'joinTable' => array(
+                    'name' => 'article__article_tags',
+                    'joinColumns' => array(
+                        array(
+                            'name' => 'article_id',
+                            'referencedColumnName' => 'id',
+                            'onDelete' => 'CASCADE',
+                        ),
+                    ),
+                    'inverseJoinColumns' => array(
+                        array(
+                            'name' => 'tag_id',
+                            'referencedColumnName' => 'id',
+                            'onDelete' => 'CASCADE',
+                        ),
+                    ),
+                ),
+            ));
+        }
+
+        if (class_exists($config['class']['media'])) {
+            $collector->addAssociation($config['class']['article'], 'mapManyToOne', array(
+                'fieldName' => 'mainImage',
+                'targetEntity' => $config['class']['media'],
+                'cascade' => array(
+                    'persist',
+                ),
+                'mappedBy' => null,
                 'joinColumns' => array(
                     array(
-                        'name' => 'article_id',
+                        'name' => 'main_image_id',
                         'referencedColumnName' => 'id',
-                        'onDelete' => 'CASCADE',
                     ),
                 ),
-                'inverseJoinColumns' => array(
-                    array(
-                        'name' => 'category_id',
-                        'referencedColumnName' => 'id',
-                        'onDelete' => 'CASCADE',
-                    ),
-                ),
-            ),
-        ));
-        $collector->addAssociation($config['class']['article'], 'mapManyToMany', array(
-            'fieldName' => 'tags',
-            'targetEntity' => $config['class']['tag'],
-            'cascade' => array(),
-            'joinTable' => array(
-                'name' => 'article__article_tags',
-                'joinColumns' => array(
-                    array(
-                        'name' => 'article_id',
-                        'referencedColumnName' => 'id',
-                        'onDelete' => 'CASCADE',
-                    ),
-                ),
-                'inverseJoinColumns' => array(
-                    array(
-                        'name' => 'tag_id',
-                        'referencedColumnName' => 'id',
-                        'onDelete' => 'CASCADE',
-                    ),
-                ),
-            ),
-        ));
-        $collector->addAssociation($config['class']['article'], 'mapManyToOne', array(
-            'fieldName' => 'mainImage',
-            'targetEntity' => $config['class']['media'],
-            'cascade' => array(
-                'persist',
-            ),
-            'mappedBy' => null,
-            'joinColumns' => array(
-                array(
-                    'name' => 'main_image_id',
-                    'referencedColumnName' => 'id',
-                ),
-            ),
-            'orphanRemoval' => false,
-        ));
+                'orphanRemoval' => false,
+            ));
+        }
 
         $collector->addAssociation($config['class']['fragment'], 'mapManyToOne', array(
             'fieldName' => 'article',


### PR DESCRIPTION
## Changelog

``` markdown
### Changed
 - Make doctrine mapping optional

```
## Subject

I need to override fully the doctrine mapping because I've got a more complex mapping.
So I need to keep Article/Fragments mapping but not Categories, tags, media.

With this PR it's now possible, you just don't have to define class variables and it's possible.

This PR is really important to us, and if possible needs to be merged ASAP.
