### PR TITLE
Add fragment helper to render them in front

### DIFF
--- a/DependencyInjection/CompilerPass/FragmentsCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FragmentsCompilerPass.php
@@ -41,6 +41,11 @@ final class FragmentsCompilerPass implements CompilerPassInterface
             $fragmentAdminDef->addMethodCall('setFragmentServices', array($fragmentServices));
         }
 
+        if ($container->hasDefinition('sonata.article.helper.fragment')) {
+            $fragmentAdminDef = $container->getDefinition('sonata.article.helper.fragment');
+            $fragmentAdminDef->addMethodCall('setFragmentServices', array($fragmentServices));
+        }
+
         if ($container->hasDefinition('sonata.article.fragment.validator')) {
             $fragmentValidDef = $container->getDefinition('sonata.article.fragment.validator');
             $fragmentValidDef->replaceArgument(0, $fragmentServices);

--- a/DependencyInjection/SonataArticleExtension.php
+++ b/DependencyInjection/SonataArticleExtension.php
@@ -35,6 +35,8 @@ final class SonataArticleExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('admin.xml');
         $loader->load('fragments.xml');
+        $loader->load('helper.xml');
+        $loader->load('twig.xml');
 
         $this->registerParameters($container, $config);
         $this->registerDoctrineMapping($config);

--- a/FragmentService/AbstractFragmentService.php
+++ b/FragmentService/AbstractFragmentService.php
@@ -120,4 +120,9 @@ abstract class AbstractFragmentService implements FragmentServiceInterface
     {
         return 'SonataArticleBundle:FragmentAdmin:form.html.twig';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function getTemplate();
 }

--- a/FragmentService/FragmentServiceInterface.php
+++ b/FragmentService/FragmentServiceInterface.php
@@ -65,4 +65,11 @@ interface FragmentServiceInterface
      * @return string
      */
     public function getEditTemplate();
+
+    /**
+     * Gets template to render fragment.
+     *
+     * @return string
+     */
+    public function getTemplate();
 }

--- a/FragmentService/TextFragmentService.php
+++ b/FragmentService/TextFragmentService.php
@@ -52,4 +52,12 @@ class TextFragmentService extends AbstractFragmentService
             ;
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplate()
+    {
+        return 'SonataArticleBundle:Fragment:fragment_text.html.twig';
+    }
 }

--- a/FragmentService/TitleFragmentService.php
+++ b/FragmentService/TitleFragmentService.php
@@ -61,4 +61,12 @@ class TitleFragmentService extends AbstractFragmentService
             ;
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplate()
+    {
+        return 'SonataArticleBundle:Fragment:fragment_title.html.twig';
+    }
 }

--- a/Helper/FragmentHelper.php
+++ b/Helper/FragmentHelper.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Helper;
+
+use Sonata\ArticleBundle\FragmentService\FragmentServiceInterface;
+use Sonata\ArticleBundle\Model\FragmentInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+/**
+ * @author Sylvain Rascar <rascar.sylvain@gmail.com>
+ */
+class FragmentHelper
+{
+    /**
+     * @var EngineInterface
+     */
+    protected $templating;
+
+    /**
+     * @var FragmentServiceInterface[]
+     */
+    protected $fragmentServices = array();
+
+    /**
+     * FragmentHelper constructor.
+     *
+     * @param EngineInterface $templating
+     */
+    public function __construct(EngineInterface $templating)
+    {
+        $this->templating = $templating;
+    }
+
+    /**
+     * @param FragmentServiceInterface[] $fragmentServices
+     */
+    final public function setFragmentServices(array $fragmentServices)
+    {
+        $this->fragmentServices = $fragmentServices;
+    }
+
+    /**
+     * @return FragmentServiceInterface[]
+     */
+    public function getFragmentServices()
+    {
+        return $this->fragmentServices;
+    }
+
+    /**
+     * @param FragmentInterface $fragment
+     *
+     * @return string
+     */
+    public function render(FragmentInterface $fragment)
+    {
+        $type = $fragment->getType();
+
+        if (!array_key_exists($type, $this->fragmentServices)) {
+            throw new \RuntimeException(sprintf('Cannot render Fragment of type `%s`. Service not found.', $type));
+        }
+
+        return $this->templating->render(
+            $this->fragmentServices[$type]->getTemplate(),
+            array(
+                'fragment' => $fragment,
+                'fields' => $fragment->getSettings(),
+            )
+        );
+    }
+}

--- a/Model/AbstractFragment.php
+++ b/Model/AbstractFragment.php
@@ -38,6 +38,8 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
 
     /**
      * @var array
+     *
+     * @todo rename settings property into fields
      */
     protected $settings;
 

--- a/Resources/config/helper.xml
+++ b/Resources/config/helper.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.article.helper.fragment" class="Sonata\ArticleBundle\Helper\FragmentHelper">
+            <argument type="service" id="templating"/>
+        </service>
+    </services>
+</container>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.article.twig.fragment" class="Sonata\ArticleBundle\Twig\FragmentExtension">
+            <tag name="twig.extension"/>
+            <argument type="service" id="sonata.article.helper.fragment"/>
+        </service>
+    </services>
+</container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -13,3 +13,4 @@ Reference Guide
    reference/installation
    reference/getting_started
    reference/configuration
+   reference/custom_fragment

--- a/Resources/doc/reference/custom_fragment.rst
+++ b/Resources/doc/reference/custom_fragment.rst
@@ -1,0 +1,84 @@
+Creating a Custom Fragment
+==========================
+
+
+Defining a fragment Service
+---------------------------
+
+First you need to create a class that extends ``Sonata\ArticleBundle\FragmentService\AbstractFragmentService``
+
+
+.. code-block:: php
+
+    namespace Acme\DummyBundle\FragmentService;
+
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\ArticleBundle\Model\FragmentInterface;
+
+    class MyAwesomeFragmentService extends AbstractFragmentService
+    {
+        public function buildEditForm(FormMapper $form, FragmentInterface $fragment)
+        {
+            $form->add('settings', 'sonata_type_immutable_array', array(
+                'keys' => array(
+                    array('text', 'text', array(
+                        'label' => 'Text',
+                    )),
+                    array('text2', 'textarea', array(
+                        'label' => 'Text 2',
+                    )),
+                ),
+                'label' => false,
+            ));
+        }
+
+        public function getTemplate()
+        {
+            return 'AcmeDummyBundle:Fragment:fragment_my_awesome.html.twig';
+        }
+    }
+
+
+Using ``settings`` field with ``keys`` option in ``buildEditForm`` method, you can define all elements that compose your fragment.
+Every key is a field that is displayed on the fragment edit form.
+The ``getTemplate`` method allows you to define which template should be used when rendering this fragment type.
+
+
+Then you need to declare the service:
+
+
+.. code-block:: yaml
+
+    services:
+        acme.dummy.fragment.my_awsome:
+            class: Acme\DummyBundle\FragmentService\MyAwesomeFragmentService
+            arguments:
+                - My Awesome Fragment Name # Fragment name in admin interface
+            tags:
+                - { name: sonata.article.fragment, key: acme.dummy.fragment.my_awesome }
+                # Where key is your fragment type unique identifier
+
+
+Defining a fragment template
+----------------------------
+
+To render the fragment, simply create a template as you defined it in the service.
+Using the twig helper, you will be able to access the following variables inside this template:
+
+* ``fragment`` : The full fragment object.
+* ``fields`` : The values that were set in fragment settings.
+
+
+.. code-block:: jinja
+
+    {# article_template.html.twig #}
+    {# ... #}
+    {{ sonata_article_render_article_fragments(article) }}
+    {# ... #}
+
+
+.. code-block:: jinja
+
+    {# AcmeDummyBundle:Fragment:fragment_my_awesome.html.twig #}
+    <h2>{{ fields.text }}</h2>
+    <p>{{ fields.text2 }}</p>

--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -99,11 +99,53 @@ Render article fragments
 ------------------------
 
 **This part is currently in development.**
-The goal is to provide a simple twig helper which will render each fragments associated to an article.
-Each fragment has its own template, this twig function is going to need to fetch in ``FragmentService`` the template,
-then render it.
+SonataArticleBundle now comes with a twig helper which allows you to render article fragments
+if they are enabled.
 
 
 .. code-block:: jinja
 
-    {{ sonata_article_render_fragments(article) }}
+    {{ sonata_article_render_article_fragments(article) }}
+
+
+Or a specific fragment whether it is enabled or not.
+
+
+.. code-block:: jinja
+
+    {{ sonata_article_render_fragment(article.fragments[0]) }}
+
+
+This extension is based on the FragmentHelper class so you can also render fragments directly
+in the controller.
+
+
+.. code-block:: php
+
+    /**
+     * Article index action
+     *
+     * @param Request $request
+     * @param string  $id
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function indexAction(Request $request, $id)
+    {
+        $article = $this->entityManager->find(Article::class, $id);
+
+        // ...
+
+        $fragmentsRender = '';
+        $fragmentsHelper = $this->get('sonata.article.helper.fragment');
+
+        foreach ($article->getFragments() as $fragment) {
+            if ($fragment->getEnabled()) {
+                $fragmentsRender .= $this->renderFragment($fragment);
+            }
+        }
+
+        // ...
+    }

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -55,7 +55,7 @@ You will need to configure SonataArticleBundle's entities, if you plan to use th
                 article:  Application\Sonata\ArticleBundle\Entity\Article
                 fragment: Application\Sonata\ArticleBundle\Entity\Fragment
 
-            fragments: # this is currently in development, hope will getting this soon :)
+            fragments: # this is currently in development, hope we'll get this soon :)
                 sonata.article.fragment.title:
                 sonata.article.fragment.text:
 

--- a/Resources/views/Fragment/fragment_text.html.twig
+++ b/Resources/views/Fragment/fragment_text.html.twig
@@ -1,0 +1,3 @@
+<p>
+    {{ fields.text|raw }}
+</p>

--- a/Resources/views/Fragment/fragment_title.html.twig
+++ b/Resources/views/Fragment/fragment_title.html.twig
@@ -1,0 +1,3 @@
+<h3>
+    {{ fields.title|raw }}
+</h3>

--- a/Tests/Helper/FragmentHelperTest.php
+++ b/Tests/Helper/FragmentHelperTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Tests\Helper;
+
+use Sonata\ArticleBundle\FragmentService\FragmentServiceInterface;
+use Sonata\ArticleBundle\Helper\FragmentHelper;
+use Sonata\ArticleBundle\Model\FragmentInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+/**
+ * @author Sylvain Rascar <rascar.sylvain@gmail.com>
+ */
+class FragmentHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Sonata\ArticleBundle\Helper\FragmentHelper
+     */
+    protected $fragmentHelper;
+
+    /**
+     * @var EngineInterface
+     */
+    protected $templating;
+
+    protected function setUp()
+    {
+        $this->templating = $this->getMockBuilder(EngineInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('render', 'exists', 'supports'))
+            ->getMock();
+
+        $this->fragmentHelper = new FragmentHelper($this->templating);
+    }
+
+    public function testRenderWithoutService()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot render Fragment of type `foo.bar`. Service not found.');
+
+        // templating render should not be called
+        $this->templating->expects($this->never())->method('render');
+
+        $fragment = $this->getFragmentMock();
+        $this->fragmentHelper->render($fragment);
+    }
+
+    public function testRender()
+    {
+        $fragment = $this->getFragmentMock();
+
+        // templating render must be called once
+        $this->templating->expects($this->once())->method('render')->will($this->returnValue('foo'));
+
+        $fragmentService = $this->createMock(FragmentServiceInterface::class);
+        $fragmentService->expects($this->once())->method('getTemplate')->will($this->returnValue('template.html.twig'));
+
+        $this->fragmentHelper->setFragmentServices(array('foo.bar' => $fragmentService));
+        $this->fragmentHelper->render($fragment);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getFragmentMock()
+    {
+        $fragment = $this->createMock(FragmentInterface::class);
+        $fragment->expects($this->once())->method('getType')->will($this->returnValue('foo.bar'));
+        $fragment->expects($this->any())->method('getSettings')->will($this->returnValue(array()));
+
+        return $fragment;
+    }
+}

--- a/Tests/Twig/FragmentExtensionTest.php
+++ b/Tests/Twig/FragmentExtensionTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Tests\Twig;
+
+use Sonata\ArticleBundle\Helper\FragmentHelper;
+use Sonata\ArticleBundle\Model\ArticleInterface;
+use Sonata\ArticleBundle\Model\FragmentInterface;
+use Sonata\ArticleBundle\Twig\FragmentExtension;
+
+/**
+ * @author Sylvain Rascar <rascar.sylvain@gmail.com>
+ */
+class FragmentExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Sonata\ArticleBundle\Helper\FragmentHelper
+     */
+    protected $fragmentHelper;
+
+    /**
+     * @var \Sonata\ArticleBundle\Twig\FragmentExtension
+     */
+    protected $fragmentExtension;
+
+    protected function setUp()
+    {
+        $this->fragmentHelper = $this->getMockBuilder(FragmentHelper::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('render'))
+            ->getMock();
+
+        $this->fragmentExtension = new FragmentExtension($this->fragmentHelper);
+    }
+
+    public function testRenderFragment()
+    {
+        // We render one fragment
+        $fragment = $this->getFragmentMock(
+            array(
+                'title' => 'foo',
+                'body' => 'bar',
+            )
+        );
+
+        $this->fragmentHelper->expects($this->once())
+            ->method('render')
+            ->willReturnCallback(array($this, 'renderFragment'));
+
+        $this->assertEquals(
+            '<h1>foo</h1><p>bar</p>',
+            $this->fragmentExtension->renderFragment($fragment)
+        );
+    }
+
+    public function testRenderArticleFragment()
+    {
+        $fragments = array();
+
+        // We render 3 fragments with one disabled
+        for ($i = 0; $i < 3; ++$i) {
+            $fragments[] = $this->getFragmentMock(
+                array(
+                    'title' => 'foo'.$i,
+                    'body' => 'bar'.$i,
+                ),
+                !($i % 2)
+            );
+        }
+
+        $article = $this->createMock(ArticleInterface::class);
+        $article->expects($this->any())
+            ->method('getFragments')
+            ->will($this->returnValue($fragments));
+
+        // we expect only two calls
+        $this->fragmentHelper->expects($this->at(0))
+            ->method('render')
+            ->willReturnCallback(array($this, 'renderFragment'));
+        $this->fragmentHelper->expects($this->at(1))
+            ->method('render')
+            ->willReturnCallback(array($this, 'renderFragment'));
+
+        $this->assertEquals(
+            '<h1>foo0</h1><p>bar0</p><h1>foo2</h1><p>bar2</p>',
+            $this->fragmentExtension->renderArticleFragments($article)
+        );
+    }
+
+    public function renderFragment(FragmentInterface $fragment)
+    {
+        $fields = $fragment->getSettings();
+
+        return sprintf('<h1>%s</h1><p>%s</p>', $fields['title'], $fields['body']);
+    }
+
+    /**
+     * @param array $settings
+     * @param bool  $enabled
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getFragmentMock(array $settings, $enabled = true)
+    {
+        $fragment = $this->createMock(FragmentInterface::class);
+        $fragment->expects($this->any())
+            ->method('getSettings')
+            ->will($this->returnValue($settings));
+        $fragment->expects($this->any())
+            ->method('getEnabled')
+            ->will($this->returnValue($enabled));
+
+        return $fragment;
+    }
+}

--- a/Twig/FragmentExtension.php
+++ b/Twig/FragmentExtension.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Twig;
+
+use Sonata\ArticleBundle\Helper\FragmentHelper;
+use Sonata\ArticleBundle\Model\ArticleInterface;
+use Sonata\ArticleBundle\Model\FragmentInterface;
+
+/**
+ * @author Sylvain Rascar <rascar.sylvain@gmail.com>
+ */
+class FragmentExtension extends \Twig_Extension
+{
+    /**
+     * @var FragmentHelper
+     */
+    protected $fragmentHelper;
+
+    /**
+     * @param FragmentHelper $fragmentHelper
+     */
+    public function __construct(FragmentHelper $fragmentHelper)
+    {
+        $this->fragmentHelper = $fragmentHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction(
+                'sonata_article_render_fragment',
+                array($this, 'renderFragment'),
+                array('is_safe' => array('html'))
+            ),
+            new \Twig_SimpleFunction(
+                'sonata_article_render_article_fragments',
+                array($this, 'renderArticleFragments'),
+                array('is_safe' => array('html'))
+            ),
+        );
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'fragment_extension';
+    }
+
+    /**
+     * @param FragmentInterface $fragment
+     *
+     * @return string
+     */
+    public function renderFragment(FragmentInterface $fragment)
+    {
+        return $this->fragmentHelper->render($fragment);
+    }
+
+    /**
+     * @param ArticleInterface $article
+     *
+     * @return string
+     */
+    public function renderArticleFragments(ArticleInterface $article)
+    {
+        $output = '';
+
+        foreach ($article->getFragments() as $fragment) {
+            if ($fragment->getEnabled()) {
+                $output .= $this->renderFragment($fragment);
+            }
+        }
+
+        return $output;
+    }
+}


### PR DESCRIPTION
## Changelog

``` markdown
### Added
- Added `TwigExtension` to wrap FragmentHelper in twig templates
- Added `FragmentHelper` to render Fragments
- Associated Unit Tests and Doc

### Changed
- Updated doc
- Updated `FragmentService` to add a getTemplate method 

```
## Subject

This PR comes with everything you need to handle the rendering of article's fragments
