### PR TITLE
Show help texts by extending the correct form template

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -1,4 +1,4 @@
-{% extends 'SonataAdminBundle:Form:filter_admin_fields.html.twig' %}
+{% extends 'SonataAdminBundle:Form:form_admin_fields.html.twig' %}
 
 {% block sonata_admin_collection_fragment %}
     {% include 'SonataArticleBundle:FragmentAdmin:edit_collection_fragment.html.twig' %}


### PR DESCRIPTION
## Changelog

``` markdown
### Fixed
- help texts were not shown, due to extending the wrong form template
```
## Subject

We were extending the wrong twig template, so it's just a small fix
