### PR TITLE
Add fragment backoffice title and improve validation

### DIFF
--- a/Admin/ArticleAdmin.php
+++ b/Admin/ArticleAdmin.php
@@ -108,6 +108,11 @@ class ArticleAdmin extends AbstractAdmin
                     AbstractArticle::getStatuses() : AbstractArticle::getContributorStatus()))
             ->end()
         ;
+
+        $fragmentAdmin = $this->getChild('sonata.article.admin.fragment');
+        foreach ($object->getFragments() as $fragment) {
+            $fragmentAdmin->validate($errorElement, $fragment);
+        }
     }
 
     /**

--- a/FragmentService/AbstractFragmentService.php
+++ b/FragmentService/AbstractFragmentService.php
@@ -55,6 +55,16 @@ abstract class AbstractFragmentService implements FragmentServiceInterface
      */
     public function buildEditForm(FormMapper $form, FragmentInterface $fragment)
     {
+        // Add BO title
+        $form->add('backofficeTitle');
+        $this->buildForm($form, $fragment);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormMapper $form, FragmentInterface $fragment)
+    {
     }
 
     /**

--- a/FragmentService/AbstractFragmentService.php
+++ b/FragmentService/AbstractFragmentService.php
@@ -13,8 +13,8 @@ namespace Sonata\ArticleBundle\FragmentService;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\ArticleBundle\Model\FragmentInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -109,8 +109,13 @@ abstract class AbstractFragmentService implements FragmentServiceInterface
     /**
      * {@inheritdoc}
      */
-    public function validate(FragmentInterface $fragment, ExecutionContextInterface $context)
+    public function validate(ErrorElement $errorElement, $object)
     {
+        if (empty($object->getBackofficeTitle())) {
+            $errorElement
+                ->addViolation(sprintf('Fragment %s - `Backoffice Title` must not be empty', $this->getName()))
+            ;
+        }
     }
 
     /**

--- a/FragmentService/FragmentServiceInterface.php
+++ b/FragmentService/FragmentServiceInterface.php
@@ -13,8 +13,8 @@ namespace Sonata\ArticleBundle\FragmentService;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\ArticleBundle\Model\FragmentInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -42,8 +42,13 @@ interface FragmentServiceInterface
      *
      * @param FragmentInterface         $fragment
      * @param ExecutionContextInterface $context
+    /**
+     * Validates the fragment (you'll need to add your violations through $errorElement).
+     *
+     * @param ErrorElement $errorElement
+     * @param object       $object
      */
-    public function validate(FragmentInterface $fragment, ExecutionContextInterface $context);
+    public function validate(ErrorElement $errorElement, $object);
 
     /**
      * Returns the Fragment service readable name.

--- a/FragmentService/FragmentServiceInterface.php
+++ b/FragmentService/FragmentServiceInterface.php
@@ -38,10 +38,13 @@ interface FragmentServiceInterface
     public function buildCreateForm(FormMapper $form, FragmentInterface $fragment);
 
     /**
-     * Validates the fragment (you'll need to add your violations through context).
+     * Builds the common part of creation|edition form for the fragment.
      *
-     * @param FragmentInterface         $fragment
-     * @param ExecutionContextInterface $context
+     * @param FormMapper        $form
+     * @param FragmentInterface $fragment
+     */
+    public function buildForm(FormMapper $form, FragmentInterface $fragment);
+
     /**
      * Validates the fragment (you'll need to add your violations through $errorElement).
      *

--- a/FragmentService/TextFragmentService.php
+++ b/FragmentService/TextFragmentService.php
@@ -13,8 +13,8 @@ namespace Sonata\ArticleBundle\FragmentService;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\ArticleBundle\Model\FragmentInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -42,13 +42,11 @@ class TextFragmentService extends AbstractFragmentService
     /**
      * {@inheritdoc}
      */
-    public function validate(FragmentInterface $fragment, ExecutionContextInterface $context)
+    public function validate(ErrorElement $errorElement, $object)
     {
-        if (empty($fragment->getSettings()['text'])) {
-            $context
-                ->buildViolation('`Text` must not be empty')
-                ->atPath('settings.text')
-                ->addViolation()
+        if (empty($object->getSetting('text'))) {
+            $errorElement
+                ->addViolation('Fragment Text - `Text` must not be empty')
             ;
         }
     }

--- a/FragmentService/TextFragmentService.php
+++ b/FragmentService/TextFragmentService.php
@@ -24,7 +24,7 @@ class TextFragmentService extends AbstractFragmentService
     /**
      * {@inheritdoc}
      */
-    public function buildEditForm(FormMapper $form, FragmentInterface $fragment)
+    public function buildForm(FormMapper $form, FragmentInterface $fragment)
     {
         $form->add('settings', 'sonata_type_immutable_array', array(
             'keys' => array(

--- a/FragmentService/TitleFragmentService.php
+++ b/FragmentService/TitleFragmentService.php
@@ -13,9 +13,9 @@ namespace Sonata\ArticleBundle\FragmentService;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\ArticleBundle\Model\FragmentInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -44,20 +44,17 @@ class TitleFragmentService extends AbstractFragmentService
     /**
      * {@inheritdoc}
      */
-    public function validate(FragmentInterface $fragment, ExecutionContextInterface $context)
+    public function validate(ErrorElement $errorElement, $object)
     {
-        if (empty($fragment->getSettings()['text'])) {
-            $context
-                ->buildViolation('`Title` must not be empty')
-                ->atPath('settings.text')
-                ->addViolation()
+        if (empty($object->getSetting('text'))) {
+            $errorElement
+                ->addViolation('Fragment Title - `Text` must not be empty')
             ;
         }
-        if (strlen($fragment->getSetting('text')) > 255) {
-            $context
-                ->buildViolation('`Title` must not be longer than 255 characters.')
-                ->atPath('settings.text')
-                ->addViolation()
+
+        if (strlen($object->getSetting('text')) > 255) {
+            $errorElement
+                ->addViolation('Fragment Text - `Text` must not be longer than 255 characters.')
             ;
         }
     }

--- a/FragmentService/TitleFragmentService.php
+++ b/FragmentService/TitleFragmentService.php
@@ -25,7 +25,7 @@ class TitleFragmentService extends AbstractFragmentService
     /**
      * {@inheritdoc}
      */
-    public function buildEditForm(FormMapper $form, FragmentInterface $fragment)
+    public function buildForm(FormMapper $form, FragmentInterface $fragment)
     {
         $form->add('settings', 'sonata_type_immutable_array', array(
             'keys' => array(

--- a/Model/AbstractFragment.php
+++ b/Model/AbstractFragment.php
@@ -49,18 +49,23 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
     protected $position;
 
     /**
-     * @var int
+     * @var string
+     */
+    protected $backofficeTitle;
+
+    /**
+     * @var ArticleInterface
      */
     protected $article;
 
     /**
-     * Returns type of fragment.
+     * Returns Backoffice title of fragment.
      *
      * @return string
      */
     public function __toString()
     {
-        return (string) $this->getType();
+        return $this->getBackofficeTitle();
     }
 
     /**
@@ -217,5 +222,25 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
     public function getUpdatedAt()
     {
         return $this->updatedAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBackofficeTitle()
+    {
+        return $this->backofficeTitle;
+    }
+
+    /**
+     * @param string $backofficeTitle
+     *
+     * @return $this
+     */
+    public function setBackofficeTitle($backofficeTitle)
+    {
+        $this->backofficeTitle = $backofficeTitle;
+
+        return $this;
     }
 }

--- a/Resources/config/doctrine/AbstractFragment.orm.xml
+++ b/Resources/config/doctrine/AbstractFragment.orm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Sonata\ArticleBundle\Entity\AbstractFragment">
+        <field name="backofficeTitle" type="string" column="backoffice_title" length="255"/>
         <field name="position" type="integer" column="position" nullable="true"/>
         <field name="settings" type="json" column="settings"/>
         <field name="type" type="string" column="type" length="64"/>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -14,3 +14,4 @@ Reference Guide
    reference/getting_started
    reference/configuration
    reference/custom_fragment
+   reference/todo

--- a/Resources/doc/reference/todo.rst
+++ b/Resources/doc/reference/todo.rst
@@ -1,0 +1,11 @@
+Todo
+====
+
+This bundle is still a work in progress, we need to work more on some parts.
+We will try to keep this "Todo list" up to date to inform you of our expectations.
+
+- Find a better way to handle fragment validation
+- Add articleTranslation feature (each articles are translatable and related to a Site)
+- Publishing Workflow
+- Handle formats (web, json, ...)
+- Duplicate article

--- a/Resources/public/js/editOneAssociationFragment.js
+++ b/Resources/public/js/editOneAssociationFragment.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function() {
 
     var id = $selector.data('id');
     var fragmentAddUrl = $selector.data('add-fragment-url');
+    var translations = $selector.data('translations');
 
     /**
      * Get URL value to POST a new fragment
@@ -34,6 +35,7 @@ jQuery(document).ready(function() {
         formSource: '#field_widget_'+id,
         addButtonSource: '#field_actions_'+id,
         getAddUrl: getFragmentAddUrl,
-        addedCallback: addFragmentCallback
+        addedCallback: addFragmentCallback,
+        translations: translations
     });
 });

--- a/Resources/translations/SonataArticleBundle.en.xliff
+++ b/Resources/translations/SonataArticleBundle.en.xliff
@@ -74,6 +74,10 @@
                 <source>form.label_backoffice_title</source>
                 <target>Backoffice title</target>
             </trans-unit>
+            <trans-unit id="remove_confirm">
+                <source>remove_confirm</source>
+                <target>The fragment will be deleted after update. Are you sure ?</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataArticleBundle.en.xliff
+++ b/Resources/translations/SonataArticleBundle.en.xliff
@@ -70,6 +70,10 @@
                 <source>form.label_publication_ends_at</source>
                 <target>Publication end date</target>
             </trans-unit>
+            <trans-unit id="form.label_backoffice_title">
+                <source>form.label_backoffice_title</source>
+                <target>Backoffice title</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataArticleBundle.fr.xliff
+++ b/Resources/translations/SonataArticleBundle.fr.xliff
@@ -74,6 +74,10 @@
                 <source>form.label_backoffice_title</source>
                 <target>Titre backoffice</target>
             </trans-unit>
+            <trans-unit id="remove_confirm">
+                <source>remove_confirm</source>
+                <target>Ce fragment sera supprimé après mise à jour. Êtes-vous certain ?</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataArticleBundle.fr.xliff
+++ b/Resources/translations/SonataArticleBundle.fr.xliff
@@ -70,6 +70,10 @@
                 <source>form.label_publication_ends_at</source>
                 <target>Date de fin de publication</target>
             </trans-unit>
+            <trans-unit id="form.label_backoffice_title">
+                <source>form.label_backoffice_title</source>
+                <target>Titre backoffice</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/FragmentAdmin/edit_collection_fragment.html.twig
+++ b/Resources/views/FragmentAdmin/edit_collection_fragment.html.twig
@@ -14,7 +14,10 @@
                                 'subclass':  sonata_admin.admin.getActiveSubclassCode(),
                                 'objectId':  sonata_admin.admin.root.subject ? sonata_admin.admin.root.id(sonata_admin.admin.root.subject) : false,
                                 'uniqid':    sonata_admin.admin.root.uniqid
-                            } + sonata_admin.field_description.getOption('link_parameters', {})) }}">
+                            } + sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                            data-translations="{{ {
+                                remove_confirm: 'remove_confirm'|trans({}, 'SonataArticleBundle')
+                            }|json_encode }}">
                         {% for fragServId, fragServ in sonata_admin.field_description.associationadmin.fragmentServices %}
                         <option value="{{ fragServId }}">{{ fragServ.name }}</option>
                         {% endfor %}

--- a/Resources/views/FragmentAdmin/form.html.twig
+++ b/Resources/views/FragmentAdmin/form.html.twig
@@ -1,6 +1,6 @@
 {% block form %}
     {% set fragmentName = admin.fragmentServices[form.vars.data.type].name %}
-    <div data-fragment-form="{{ form.vars.id }}" data-form-tmp="true" data-formdata='{ "name": "Fragment {{ fragmentName }}", "type": "{{ fragmentName }}" }' data-errors="{{ form.vars.errors|length }}">
+    <div data-fragment-form="{{ form.vars.id }}" data-form-tmp="true" data-formdata='{ "name": "Fragment {{ fragmentName }}", "type": "{{ form.vars.data.backofficeTitle }}" }' data-errors="{{ form.vars.errors|length }}">
         <div class="col-md-12">
             <div class="box box-primary">
                 <div class="box-header">
@@ -9,7 +9,7 @@
                     </h4>
                 </div>
                 <div class="box-body">
-                    {% if form.vars.errors|length > 0 %}
+                    {% if form.vars.errors is defined and form.vars.errors|length > 0 %}
                         <div class="sonata-ba-form-error">
                             {{ form_errors(form) }}
                         </div>

--- a/Resources/views/FragmentAdmin/form.html.twig
+++ b/Resources/views/FragmentAdmin/form.html.twig
@@ -1,6 +1,9 @@
 {% block form %}
     {% set fragmentName = admin.fragmentServices[form.vars.data.type].name %}
-    <div data-fragment-form="{{ form.vars.id }}" data-form-tmp="true" data-formdata='{ "name": "Fragment {{ fragmentName }}", "type": "{{ form.vars.data.backofficeTitle }}" }' data-errors="{{ form.vars.errors|length }}">
+    <div data-fragment-form="{{ form.vars.id }}"
+         data-form-tmp="true"
+         data-formdata='{ "name": "Fragment {{ fragmentName }}", "type": "{{ form.vars.data.backofficeTitle }}" }'
+         data-errors="{{ form.vars.errors|length }}">
         <div class="col-md-12">
             <div class="box box-primary">
                 <div class="box-header">
@@ -9,7 +12,7 @@
                     </h4>
                 </div>
                 <div class="box-body">
-                    {% if form.vars.errors is defined and form.vars.errors|length > 0 %}
+                    {% if form.vars.errors|default([])|length > 0 %}
                         <div class="sonata-ba-form-error">
                             {{ form_errors(form) }}
                         </div>


### PR DESCRIPTION
## Changelog

```markdown
### Added
- Fragment "Backoffice title"

### Changed
- FragmentService `buildEditForm` now call `buildForm` to add backoffice title to each fragments
- FragmentService validate signature
```
## Subject

The goal of this PR is to handle new backoffice title for each fragments. This improve the readability of the admin, instead of seeing only the fragment type, you will see a label related to your content. Also, the validate signature was wrong, because it's called from the article admin.

Before
------
![capture d ecran 2016-12-01 a 10 46 49](https://cloud.githubusercontent.com/assets/1943676/20789088/81d3a2e6-b7b3-11e6-8cc3-aa10f6a28d2a.png)

After 
-----
![capture d ecran 2016-12-01 a 10 46 07](https://cloud.githubusercontent.com/assets/1943676/20789095/88aafeac-b7b3-11e6-82c1-69d2e338ac71.png)
