### PR TITLE
Fix setTags type on article setter

### DIFF
--- a/Model/AbstractArticle.php
+++ b/Model/AbstractArticle.php
@@ -84,7 +84,7 @@ abstract class AbstractArticle implements ArticleInterface
     protected $categories;
 
     /**
-     * @var Collection
+     * @var ArrayCollection
      */
     protected $tags;
 
@@ -353,7 +353,7 @@ abstract class AbstractArticle implements ArticleInterface
     /**
      * {@inheritdoc}
      */
-    public function setTags(Collection $tags = null)
+    public function setTags(array $tags = null)
     {
         $this->tags = $tags;
 

--- a/Model/ArticleInterface.php
+++ b/Model/ArticleInterface.php
@@ -11,9 +11,9 @@
 
 namespace Sonata\ArticleBundle\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sonata\ClassificationBundle\Model\Category;
-use Sonata\ClassificationBundle\Model\Tag;
 use Sonata\MediaBundle\Model\Media;
 
 /**
@@ -156,14 +156,14 @@ interface ArticleInterface
     public function getSubtitle();
 
     /**
-     * @param Tag[]|Collection $tags
+     * @param array $tags
      *
      * @return $this
      */
-    public function setTags(Collection $tags = null);
+    public function setTags(array $tags = null);
 
     /**
-     * @return Tag[]|Collection $tags
+     * @return ArrayCollection $tags
      */
     public function getTags();
 


### PR DESCRIPTION
## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Update Article tags setter param type to be array 
```

## Subject

The goal of this PR is to fix the article tags setter to be an array. This allow fixtures to be implemented.
