### PR TITLE
define FragmentAdmin not final

### DIFF
--- a/Admin/FragmentAdmin.php
+++ b/Admin/FragmentAdmin.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-final class FragmentAdmin extends AbstractAdmin
+class FragmentAdmin extends AbstractAdmin
 {
     /**
      * @var FragmentServiceInterface[]


### PR DESCRIPTION
## Changelog

```markdown
### Changed
- FragmentAdmin class is not final anymore
```

## Subject

For custom purpose I need to override access behaviour to fragments, so I would like to be able to extend the FragmentAdmin class.
