### PR TITLE
method validate is not implemented in FragmentAdmin

### DIFF
--- a/Admin/FragmentAdmin.php
+++ b/Admin/FragmentAdmin.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\ArticleBundle\FragmentService\FragmentServiceInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -195,6 +196,14 @@ final class FragmentAdmin extends AbstractAdmin
         return array(
             'type' => $this->getRequest()->get('type'),
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(ErrorElement $errorElement, $object)
+    {
+        $this->fragmentServices[$object->getType()]->validate($errorElement, $object);
     }
 
     /**


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Implements `FragmentAdmin::validate()`
```

## Subject

While I was implementing a FragmentService (extending AbstractFragmentService), I noticed that method Validate was not called.
It seems there is no implementation for method Validate in FragmentAdmin class, and so validation for fragmentServices are not called.
