### PR TITLE
Fixed paths related to SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Article.orm.xml.skeleton
+++ b/Resources/config/doctrine/Article.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\ArticleBundle\Entity\Article"
+        name="{{ namespace }}\Entity\Article"
         table="article__article"
         >
 

--- a/Resources/config/doctrine/Fragment.orm.xml.skeleton
+++ b/Resources/config/doctrine/Fragment.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\ArticleBundle\Entity\Fragment"
+        name="{{ namespace }}\Entity\Fragment"
         table="article__fragment"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/classification-bundle": "^3.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
+        "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/media-bundle": "^3.0",
         "symfony/class-loader": "^2.8 || ^3.0",
         "symfony/config": "^2.8 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardcoded paths, which become invalid after enabling
the '--namespace' option in SonataEasyExtendsBundle's last release
(https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0)

See also: https://github.com/sonata-project/SonataMediaBundle/pull/1250