### PR TITLE
Add execute method to AbstractFragmentService

### DIFF
--- a/FragmentService/ExtraContentProviderInterface.php
+++ b/FragmentService/ExtraContentProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\FragmentService;
+
+use Sonata\ArticleBundle\Model\FragmentInterface;
+
+/**
+ * @author Benoit Mazière <benoit.maziere@ekino.com>
+ */
+interface ExtraContentProviderInterface
+{
+    /**
+     * Gets extra content (1 or multi dimensional array) to complete base fragment content.
+     *
+     * @param FragmentInterface $fragment
+     *
+     * @return array
+     */
+    public function getExtraContent(FragmentInterface $fragment);
+}

--- a/Helper/FragmentHelper.php
+++ b/Helper/FragmentHelper.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\ArticleBundle\Helper;
 
+use Sonata\ArticleBundle\FragmentService\ExtraContentProviderInterface;
 use Sonata\ArticleBundle\FragmentService\FragmentServiceInterface;
 use Sonata\ArticleBundle\Model\FragmentInterface;
 use Symfony\Component\Templating\EngineInterface;
@@ -69,12 +70,15 @@ class FragmentHelper
             throw new \RuntimeException(sprintf('Cannot render Fragment of type `%s`. Service not found.', $type));
         }
 
-        return $this->templating->render(
-            $this->fragmentServices[$type]->getTemplate(),
-            array(
-                'fragment' => $fragment,
-                'fields' => $fragment->getSettings(),
-            )
+        $content = array(
+            'fragment' => $fragment,
+            'fields' => $fragment->getSettings(),
         );
+
+        if ($this->fragmentServices[$type] instanceof ExtraContentProviderInterface) {
+            $content = array_merge($this->fragmentServices[$type]->getExtraContent($fragment), $content);
+        }
+
+        return $this->templating->render($this->fragmentServices[$type]->getTemplate(), $content);
     }
 }

--- a/Resources/doc/reference/custom_fragment.rst
+++ b/Resources/doc/reference/custom_fragment.rst
@@ -13,9 +13,10 @@ First you need to create a class that extends ``Sonata\ArticleBundle\FragmentSer
     namespace Acme\DummyBundle\FragmentService;
 
     use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\ArticleBundle\FragmentService\ExtraContentProviderInterface;
     use Sonata\ArticleBundle\Model\FragmentInterface;
 
-    class MyAwesomeFragmentService extends AbstractFragmentService
+    class MyAwesomeFragmentService extends AbstractFragmentService implements ExtraContentProviderInterface
     {
         public function buildEditForm(FormMapper $form, FragmentInterface $fragment)
         {
@@ -36,12 +37,22 @@ First you need to create a class that extends ``Sonata\ArticleBundle\FragmentSer
         {
             return 'AcmeDummyBundle:Fragment:fragment_my_awesome.html.twig';
         }
+
+        public function getExtraContent()
+        {
+            return array(
+                'foo' => 'bar',
+            );
+        }
     }
 
 
 Using ``settings`` field with ``keys`` option in ``buildEditForm`` method, you can define all elements that compose your fragment.
 Every key is a field that is displayed on the fragment edit form.
 The ``getTemplate`` method allows you to define which template should be used when rendering this fragment type.
+If needed, your custom fragment can also implement ``ExtraContentProviderInterface``.
+So you will be able to implement ``getExtraContent`` method to complete
+the content of the fragment before the templating engine renders it.
 
 
 Then you need to declare the service:
@@ -67,6 +78,7 @@ Using the twig helper, you will be able to access the following variables inside
 
 * ``fragment`` : The full fragment object.
 * ``fields`` : The values that were set in fragment settings.
+* ``foo`` : Any keys you may have defined when implementing ``ExtraContentProviderInterface``.
 
 
 .. code-block:: jinja

--- a/Tests/Helper/FragmentHelperTest.php
+++ b/Tests/Helper/FragmentHelperTest.php
@@ -58,11 +58,19 @@ class FragmentHelperTest extends \PHPUnit_Framework_TestCase
         // templating render must be called once
         $this->templating->expects($this->once())->method('render')->will($this->returnValue('foo'));
 
-        $fragmentService = $this->createMock('Sonata\ArticleBundle\FragmentService\FragmentServiceInterface');
+        $fragmentService = $this->createMock(array(
+            'Sonata\ArticleBundle\FragmentService\FragmentServiceInterface',
+            'Sonata\ArticleBundle\FragmentService\ExtraContentProviderInterface',
+        ));
         $fragmentService->expects($this->once())->method('getTemplate')->will($this->returnValue('template.html.twig'));
+        $fragmentService->expects($this->once())->method('getExtraContent')->will($this->returnValue(array('foo' => 'bar')));
 
         $this->fragmentHelper->setFragmentServices(array('foo.bar' => $fragmentService));
         $this->fragmentHelper->render($fragment);
+
+        $this->assertArrayHasKey('foo.bar', $this->fragmentHelper->getFragmentServices());
+        $this->assertInstanceOf('Sonata\ArticleBundle\FragmentService\FragmentServiceInterface',
+            $this->fragmentHelper->getFragmentServices()['foo.bar']);
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `getContent` to specify by fragment which data is sent to the template.
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject


The goal of this PR is allow control on which data is provided to the fragment view for each fragment. `getContent` can be added in each fragmentService to provide custom data to the view (by default it will keep actual behavior that is `fragment`, `fields`) .



