### PR TITLE
Drop PHPUnit 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
+/.php_cs.cache
 /composer.lock

--- a/Tests/Helper/FragmentHelperTest.php
+++ b/Tests/Helper/FragmentHelperTest.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\ArticleBundle\Tests\Helper;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\ArticleBundle\Helper\FragmentHelper;
 use Symfony\Component\Templating\EngineInterface;
 
 /**
  * @author Sylvain Rascar <rascar.sylvain@gmail.com>
  */
-class FragmentHelperTest extends \PHPUnit_Framework_TestCase
+class FragmentHelperTest extends TestCase
 {
     /**
      * @var \Sonata\ArticleBundle\Helper\FragmentHelper

--- a/Tests/Helper/FragmentHelperTest.php
+++ b/Tests/Helper/FragmentHelperTest.php
@@ -34,7 +34,7 @@ class FragmentHelperTest extends TestCase
     {
         $this->templating = $this->getMockBuilder('Symfony\Component\Templating\EngineInterface')
             ->disableOriginalConstructor()
-            ->setMethods(array('render', 'exists', 'supports'))
+            ->setMethods(['render', 'exists', 'supports'])
             ->getMock();
 
         $this->fragmentHelper = new FragmentHelper($this->templating);
@@ -59,14 +59,14 @@ class FragmentHelperTest extends TestCase
         // templating render must be called once
         $this->templating->expects($this->once())->method('render')->will($this->returnValue('foo'));
 
-        $fragmentService = $this->createMock(array(
+        $fragmentService = $this->createMock([
             'Sonata\ArticleBundle\FragmentService\FragmentServiceInterface',
             'Sonata\ArticleBundle\FragmentService\ExtraContentProviderInterface',
-        ));
+        ]);
         $fragmentService->expects($this->once())->method('getTemplate')->will($this->returnValue('template.html.twig'));
-        $fragmentService->expects($this->once())->method('getExtraContent')->will($this->returnValue(array('foo' => 'bar')));
+        $fragmentService->expects($this->once())->method('getExtraContent')->will($this->returnValue(['foo' => 'bar']));
 
-        $this->fragmentHelper->setFragmentServices(array('foo.bar' => $fragmentService));
+        $this->fragmentHelper->setFragmentServices(['foo.bar' => $fragmentService]);
         $this->fragmentHelper->render($fragment);
 
         $this->assertArrayHasKey('foo.bar', $this->fragmentHelper->getFragmentServices());
@@ -81,7 +81,7 @@ class FragmentHelperTest extends TestCase
     {
         $fragment = $this->createMock('Sonata\ArticleBundle\Model\FragmentInterface');
         $fragment->expects($this->once())->method('getType')->will($this->returnValue('foo.bar'));
-        $fragment->expects($this->any())->method('getSettings')->will($this->returnValue(array()));
+        $fragment->expects($this->any())->method('getSettings')->will($this->returnValue([]));
 
         return $fragment;
     }

--- a/Tests/Twig/FragmentExtensionTest.php
+++ b/Tests/Twig/FragmentExtensionTest.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\ArticleBundle\Tests\Twig;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\ArticleBundle\Model\FragmentInterface;
 use Sonata\ArticleBundle\Twig\FragmentExtension;
 
 /**
  * @author Sylvain Rascar <rascar.sylvain@gmail.com>
  */
-class FragmentExtensionTest extends \PHPUnit_Framework_TestCase
+class FragmentExtensionTest extends TestCase
 {
     /**
      * @var \Sonata\ArticleBundle\Helper\FragmentHelper

--- a/Tests/Twig/FragmentExtensionTest.php
+++ b/Tests/Twig/FragmentExtensionTest.php
@@ -34,7 +34,7 @@ class FragmentExtensionTest extends TestCase
     {
         $this->fragmentHelper = $this->getMockBuilder('Sonata\ArticleBundle\Helper\FragmentHelper')
             ->disableOriginalConstructor()
-            ->setMethods(array('render'))
+            ->setMethods(['render'])
             ->getMock();
 
         $this->fragmentExtension = new FragmentExtension($this->fragmentHelper);
@@ -43,16 +43,14 @@ class FragmentExtensionTest extends TestCase
     public function testRenderFragment()
     {
         // We render one fragment
-        $fragment = $this->getFragmentMock(
-            array(
-                'title' => 'foo',
-                'body' => 'bar',
-            )
-        );
+        $fragment = $this->getFragmentMock([
+            'title' => 'foo',
+            'body' => 'bar',
+        ]);
 
         $this->fragmentHelper->expects($this->once())
             ->method('render')
-            ->willReturnCallback(array($this, 'renderFragment'));
+            ->willReturnCallback([$this, 'renderFragment']);
 
         $this->assertEquals(
             '<h1>foo</h1><p>bar</p>',
@@ -62,15 +60,15 @@ class FragmentExtensionTest extends TestCase
 
     public function testRenderArticleFragment()
     {
-        $fragments = array();
+        $fragments = [];
 
         // We render 3 fragments with one disabled
         for ($i = 0; $i < 3; ++$i) {
             $fragments[] = $this->getFragmentMock(
-                array(
+                [
                     'title' => 'foo'.$i,
                     'body' => 'bar'.$i,
-                ),
+                ],
                 !($i % 2)
             );
         }
@@ -83,10 +81,10 @@ class FragmentExtensionTest extends TestCase
         // we expect only two calls
         $this->fragmentHelper->expects($this->at(0))
             ->method('render')
-            ->willReturnCallback(array($this, 'renderFragment'));
+            ->willReturnCallback([$this, 'renderFragment']);
         $this->fragmentHelper->expects($this->at(1))
             ->method('render')
-            ->willReturnCallback(array($this, 'renderFragment'));
+            ->willReturnCallback([$this, 'renderFragment']);
 
         $this->assertEquals(
             '<h1>foo0</h1><p>bar0</p><h1>foo2</h1><p>bar2</p>',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Removed compatibility with PHPUnit 4. Fixes: https://github.com/sebastianbergmann/phpunit/issues/2809