### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,11 @@
         "twig/extensions": "^1.0",
         "twig/twig": "^1.23 || ^2.0"
     },
+    "conflict": {
+        "sonata-project/block-bundle": "<3.11"
+    },
     "require-dev": {
+        "sonata-project/block-bundle": "^3.11",
         "symfony/phpunit-bridge": "^4.0"
     },
     "config": {

--- a/docs/reference/custom_fragment.rst
+++ b/docs/reference/custom_fragment.rst
@@ -35,7 +35,7 @@ First you need to create a class that extends ``Sonata\ArticleBundle\FragmentSer
 
         public function getTemplate()
         {
-            return 'AcmeDummyBundle:Fragment:fragment_my_awesome.html.twig';
+            return '@AcmeDummy/Fragment/fragment_my_awesome.html.twig';
         }
 
         public function getExtraContent()
@@ -91,6 +91,6 @@ Using the twig helper, you will be able to access the following variables inside
 
 .. code-block:: jinja
 
-    {# AcmeDummyBundle:Fragment:fragment_my_awesome.html.twig #}
+    {# @AcmeDummy/Fragment/fragment_my_awesome.html.twig #}
     <h2>{{ fields.text }}</h2>
     <p>{{ fields.text2 }}</p>

--- a/src/Admin/ArticleAdmin.php
+++ b/src/Admin/ArticleAdmin.php
@@ -96,7 +96,7 @@ class ArticleAdmin extends AbstractAdmin
     public function getTemplate($name)
     {
         if ('edit' === $name) {
-            return 'SonataArticleBundle:FragmentAdmin:edit_article.html.twig';
+            return '@SonataArticle/FragmentAdmin/edit_article.html.twig';
         }
 
         return parent::getTemplate($name);

--- a/src/Admin/FragmentAdmin.php
+++ b/src/Admin/FragmentAdmin.php
@@ -80,7 +80,7 @@ final class FragmentAdmin extends AbstractAdmin
                 return $this->getService($this->getRequest()->get('type'))->getEditTemplate();
             }
 
-            return 'SonataArticleBundle:FragmentAdmin:form.html.twig';
+            return '@SonataArticle/FragmentAdmin/form.html.twig';
         }
 
         return parent::getTemplate($name);

--- a/src/FragmentService/AbstractFragmentService.php
+++ b/src/FragmentService/AbstractFragmentService.php
@@ -135,7 +135,7 @@ abstract class AbstractFragmentService implements FragmentServiceInterface
      */
     public function getEditTemplate()
     {
-        return 'SonataArticleBundle:FragmentAdmin:form.html.twig';
+        return '@SonataArticle/FragmentAdmin/form.html.twig';
     }
 
     /**

--- a/src/FragmentService/TextFragmentService.php
+++ b/src/FragmentService/TextFragmentService.php
@@ -60,6 +60,6 @@ class TextFragmentService extends AbstractFragmentService
      */
     public function getTemplate()
     {
-        return 'SonataArticleBundle:Fragment:fragment_text.html.twig';
+        return '@SonataArticle/Fragment/fragment_text.html.twig';
     }
 }

--- a/src/FragmentService/TitleFragmentService.php
+++ b/src/FragmentService/TitleFragmentService.php
@@ -68,6 +68,6 @@ class TitleFragmentService extends AbstractFragmentService
      */
     public function getTemplate()
     {
-        return 'SonataArticleBundle:Fragment:fragment_title.html.twig';
+        return '@SonataArticle/Fragment/fragment_title.html.twig';
     }
 }

--- a/src/Resources/config/helper.xml
+++ b/src/Resources/config/helper.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.article.helper.fragment" class="Sonata\ArticleBundle\Helper\FragmentHelper">
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
     </services>
 </container>

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -1,7 +1,7 @@
-{% extends 'SonataAdminBundle:Form:form_admin_fields.html.twig' %}
+{% extends '@SonataAdmin/Form/form_admin_fields.html.twig' %}
 
 {% block sonata_admin_collection_fragment %}
-    {% include 'SonataArticleBundle:FragmentAdmin:edit_collection_fragment.html.twig' %}
+    {% include '@SonataArticle/FragmentAdmin/edit_collection_fragment.html.twig' %}
 {% endblock %}
 
 {% block sonata_type_collection_widget %}
@@ -25,7 +25,7 @@
 {%- endblock sonata_type_model_autocomplete_selection_format %}
 
 {% block sonata_article_admin_article_fragments_sonata_type_admin_widget %}
-    {% include "SonataArticleBundle:FragmentAdmin:form.html.twig" with {'admin': sonata_admin.field_description.associationadmin} %}
+    {% include "@SonataArticle/FragmentAdmin/form.html.twig" with {'admin': sonata_admin.field_description.associationadmin} %}
 {% endblock %}
 
 {% block sonata_page_admin_block_collection_settings_settings_service_widget %}

--- a/src/Resources/views/FragmentAdmin/edit_article.html.twig
+++ b/src/Resources/views/FragmentAdmin/edit_article.html.twig
@@ -1,4 +1,4 @@
-{% extends 'SonataAdminBundle:CRUD:edit.html.twig' %}
+{% extends '@SonataAdmin/CRUD/edit.html.twig' %}
 
 {% block stylesheets %}
     {{ parent() }}


### PR DESCRIPTION
I am targeting this branch, because there is only one master branch, and because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details