### PR TITLE
Fix option read-only

### DIFF
--- a/src/Admin/FragmentAdmin.php
+++ b/src/Admin/FragmentAdmin.php
@@ -251,7 +251,7 @@ final class FragmentAdmin extends AbstractAdmin
         $formMapper->add('id', HiddenType::class);
         $formMapper->add('enabled', HiddenType::class);
         $formMapper->add('position', HiddenType::class);
-        $formMapper->add('type', HiddenType::class, ['read_only' => true]);
+        $formMapper->add('type', HiddenType::class, ['attr' => ['readonly' => true]]);
 
         if (!is_object($this->getSubject())) {
             return;


### PR DESCRIPTION
## Changelog
```markdown
### Fixed
- fix attribute 'readonly' of a fragment admin field
```

## Subject

The form field option "read_only" was removed in symfony 3, now we must set an attribute.
cf. https://symfony.com/doc/2.8/reference/forms/types/text.html#read-only
