### PR TITLE
fix(fragments): fix collection usage in fragments

### DIFF
--- a/src/Controller/FragmentAdminController.php
+++ b/src/Controller/FragmentAdminController.php
@@ -57,8 +57,15 @@ class FragmentAdminController extends CRUDController
         $request = $this->getRequest();
         // We need to replace name attributes to have a s20003903[fragments][n][...] format as this form doesn't.
         // Know of its parent: s/s20003903_fragments_n/s20003903[fragments][n]
-        $search = sprintf('name="%s_%d', $request->get('elementId'), $request->get('fragCount', 0));
-        $replace = sprintf('name="%s[fragments][%d]', $request->get('uniqid'), $request->get('fragCount', 0));
+        // We're also replacing with html entity &quot; to handle name attributes in collection prototypes
+        $search = [
+            sprintf('name="%s_%d', $request->get('elementId'), $request->get('fragCount', 0)),
+            sprintf('name=&quot;%s_%d', $request->get('elementId'), $request->get('fragCount', 0)),
+        ];
+        $replace = [
+            sprintf('name="%s[fragments][%d]', $request->get('uniqid'), $request->get('fragCount', 0)),
+            sprintf('name=&quot;%s[fragments][%d]', $request->get('uniqid'), $request->get('fragCount', 0)),
+        ];
 
         $response = $this->render($this->admin->getTemplate('edit'), [
             'form' => $view,

--- a/src/Resources/public/js/fragmentList.jquery.js
+++ b/src/Resources/public/js/fragmentList.jquery.js
@@ -156,6 +156,9 @@
 
             // Update form list
             this.setFormListElement();
+            // Trigger admin shared setup on new form
+            var addedForm = this.getFormByFragmentId(id);
+            Admin.shared_setup(addedForm);
             // Append the new fragment
             this.appendFragment(id, data, true);
             // Reorder


### PR DESCRIPTION
I am targeting this branch, because this is a BC fix.

## Changelog

```markdown
### Fixed
- Fixed usage of collection widget on fragment creation
- Fixed missing admin javascript behavior on fragment creation
```
## Subject
When we're using collections in a fragment, a prototype is added as attribute to allow dynamic new items in the collection. In FragmentAdminController, there was a replacement done on the name attribute of the new form provided in ajax but in the prototype case, the quote character is rendered as an html entity. This was leading to a broken prototype. This PR add the same replacement for the html entity case.

When adding a new fragment, the form of the fragment is loaded in ajax and the `Admin.shared_setup` javascript function was not called on the new content. This was preventing all javascript behaviors tied to this function from being applied to this dom content. This PR add this call right after the dom is inserted.