### PR TITLE
Fix losing fragments on article update

### DIFF
--- a/src/Model/AbstractArticle.php
+++ b/src/Model/AbstractArticle.php
@@ -260,7 +260,7 @@ abstract class AbstractArticle implements ArticleInterface
      */
     public function setFragments($fragments = null)
     {
-        $this->fragments = new ArrayCollection();
+        $this->fragments->clear();
 
         foreach ($fragments as $fragment) {
             $this->addFragment($fragment);


### PR DESCRIPTION
I am targeting this branch, because this is a BC fix

## Changelog
```markdown
### Fixed
- Fixed losing fragments when updating an article with doctrine >= 2.6
```

## Subject
Some changes introduced in doctrine 2.6 produced a bug when updating an article. The code is updating the list of fragments by using the `Article::setFragments()` but this method defined a new ArrayCollection object. When checking for changes before updating the article object, Doctrine did not retrieve the same collection it hydrated and concluded the old collection should be dropped, leading to deletion of all fragments inside it (even if they were in the new collection).

This PR keeps the same ArrayCollection object, only clearing it before redefining fragments.