### PR TITLE
chore(version): set branch alias to 0.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "0.x-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
I am targeting this branch, because this is the only one.

## Changelog
```markdown
### Fixed
- Set branch alias to 0.x-dev in expectation of a first 0.1 tagged release
```

## Subject

Set branch alias to 0.x-dev in expectation of a first 0.1 tagged release
