### PR TITLE
chore(test): add unit tests on models and entities

### DIFF
--- a/src/Model/AbstractArticle.php
+++ b/src/Model/AbstractArticle.php
@@ -15,7 +15,7 @@ namespace Sonata\ArticleBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Sonata\MediaBundle\Model\Media;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -91,7 +91,7 @@ abstract class AbstractArticle implements ArticleInterface
     protected $tags;
 
     /**
-     * @var Media
+     * @var MediaInterface
      */
     protected $mainImage;
 
@@ -154,9 +154,11 @@ abstract class AbstractArticle implements ArticleInterface
     /**
      * {@inheritdoc}
      */
-    public function setId($id): void
+    public function setId($id)
     {
         $this->id = $id;
+
+        return $this;
     }
 
     /**
@@ -216,7 +218,7 @@ abstract class AbstractArticle implements ArticleInterface
     /**
      * {@inheritdoc}
      */
-    public function setMainImage(Media $mainImage = null)
+    public function setMainImage(MediaInterface $mainImage = null)
     {
         $this->mainImage = $mainImage;
 
@@ -237,7 +239,7 @@ abstract class AbstractArticle implements ArticleInterface
     public function addFragment(FragmentInterface $fragment)
     {
         $fragment->setArticle($this);
-        $this->fragments[] = $fragment;
+        $this->fragments->add($fragment);
 
         return $this;
     }

--- a/src/Model/ArticleInterface.php
+++ b/src/Model/ArticleInterface.php
@@ -16,7 +16,7 @@ namespace Sonata\ArticleBundle\Model;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sonata\ClassificationBundle\Model\Category;
-use Sonata\MediaBundle\Model\Media;
+use Sonata\MediaBundle\Model\MediaInterface;
 
 /**
  * @author Benoit Mazière <bmaziere@ekino.com>
@@ -72,14 +72,14 @@ interface ArticleInterface
     public function getCreatedAt();
 
     /**
-     * @param Media $mainImage
+     * @param MediaInterface $mainImage
      *
      * @return $this
      */
-    public function setMainImage(Media $mainImage = null);
+    public function setMainImage(MediaInterface $mainImage = null);
 
     /**
-     * @return Media $image
+     * @return MediaInterface $image
      */
     public function getMainImage();
 

--- a/tests/Entity/AbstractArticleTest.php
+++ b/tests/Entity/AbstractArticleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Tests\Entity;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\ArticleBundle\Entity\AbstractArticle;
+
+/**
+ * @author Romain Mouillard <romain.mouillard@gmail.com>
+ */
+class AbstractArticleTest extends TestCase
+{
+    public function testAbstractArticle(): void
+    {
+        $article = new MockArticle();
+
+        $this->assertInstanceOf(\Sonata\ArticleBundle\Model\AbstractArticle::class, $article);
+    }
+
+    public function testPrePersist(): void
+    {
+        $article = new MockArticle();
+
+        $this->assertNull($article->getCreatedAt());
+        $this->assertNull($article->getUpdatedAt());
+
+        $article->prePersist();
+
+        $this->assertInstanceOf(\DateTime::class, $article->getCreatedAt());
+        $this->assertInstanceOf(\DateTime::class, $article->getUpdatedAt());
+    }
+
+    public function testPreUpdate(): void
+    {
+        $article = new MockArticle();
+
+        $createdAt = new \DateTime();
+        $article->setCreatedAt($createdAt);
+
+        $article->preUpdate();
+
+        $this->assertSame($createdAt, $article->getCreatedAt());
+        $this->assertInstanceOf(\DateTime::class, $article->getUpdatedAt());
+        $this->assertNotSame($createdAt, $article->getUpdatedAt());
+    }
+}
+
+class MockArticle extends AbstractArticle
+{
+    public function getId(): void
+    {
+    }
+}

--- a/tests/Entity/AbstractFragmentTest.php
+++ b/tests/Entity/AbstractFragmentTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Tests\Entity;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\ArticleBundle\Entity\AbstractFragment;
+
+/**
+ * @author Romain Mouillard <romain.mouillard@gmail.com>
+ */
+class AbstractFragmentTest extends TestCase
+{
+    public function testAbstractFragment(): void
+    {
+        $fragment = new MockFragment();
+
+        $this->assertInstanceOf(\Sonata\ArticleBundle\Model\AbstractFragment::class, $fragment);
+    }
+
+    public function testPrePersist(): void
+    {
+        $fragment = new MockFragment();
+
+        $this->assertNull($fragment->getCreatedAt());
+        $this->assertNull($fragment->getUpdatedAt());
+
+        $fragment->prePersist();
+
+        $this->assertInstanceOf(\DateTime::class, $fragment->getCreatedAt());
+        $this->assertInstanceOf(\DateTime::class, $fragment->getUpdatedAt());
+    }
+
+    public function testPreUpdate(): void
+    {
+        $fragment = new MockFragment();
+
+        $createdAt = new \DateTime();
+        $fragment->setCreatedAt($createdAt);
+
+        $fragment->preUpdate();
+
+        $this->assertSame($createdAt, $fragment->getCreatedAt());
+        $this->assertInstanceOf(\DateTime::class, $fragment->getUpdatedAt());
+        $this->assertNotSame($createdAt, $fragment->getUpdatedAt());
+    }
+}
+
+class MockFragment extends AbstractFragment
+{
+    public function getId(): void
+    {
+    }
+}

--- a/tests/Model/AbstractArticleTest.php
+++ b/tests/Model/AbstractArticleTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Tests\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use PHPUnit\Framework\TestCase;
+use Sonata\ArticleBundle\Model\AbstractArticle;
+use Sonata\ArticleBundle\Model\AbstractFragment;
+use Sonata\ArticleBundle\Model\ArticleInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+/**
+ * @author Romain Mouillard <romain.mouillard@gmail.com>
+ */
+class AbstractArticleTest extends TestCase
+{
+    public function testAbstractArticleStatuses(): void
+    {
+        $allStatuses = [
+            MockArticle::STATUS_DRAFT => 'Draft',
+            MockArticle::STATUS_TO_PUBLISH => 'To publish',
+            MockArticle::STATUS_PUBLISHED => 'Published',
+            MockArticle::STATUS_ARCHIVED => 'Archived',
+        ];
+
+        $this->assertEquals($allStatuses, MockArticle::getStatuses());
+        $this->assertEquals(array_keys($allStatuses), MockArticle::getValidStatuses());
+
+        $contributorStatuses = [
+            MockArticle::STATUS_DRAFT => 'Draft',
+            MockArticle::STATUS_TO_PUBLISH => 'To publish',
+            MockArticle::STATUS_ARCHIVED => 'Archived',
+        ];
+
+        $this->assertEquals($contributorStatuses, MockArticle::getContributorStatus());
+    }
+
+    public function testAbstractArticle(): void
+    {
+        $article = new MockArticle();
+
+        $this->assertInstanceOf(ArticleInterface::class, $article);
+        $this->assertInstanceOf(Collection::class, $article->getTags());
+        $this->assertInstanceOf(Collection::class, $article->getFragments());
+        $this->assertInstanceOf(Collection::class, $article->getCategories());
+        $this->assertEquals(AbstractArticle::STATUS_DRAFT, $article->getStatus());
+    }
+
+    public function testProperties(): void
+    {
+        $article = new MockArticle();
+
+        $media = $this->createMock(MediaInterface::class);
+
+        $createdAt = new \DateTime();
+        $updatedAt = new \DateTime();
+        $validatedAt = new \DateTime();
+        $publicationStartsAt = new \DateTime();
+        $publicationEndsAt = new \DateTime();
+        $categories = new ArrayCollection();
+        $tags = [];
+
+        $article
+            ->setId(1)
+            ->setTitle('Title')
+            ->setAbstract('Abstract')
+            ->setSubtitle('Subtitle')
+            ->setStatus(1)
+            ->setCategories($categories)
+            ->setTags($tags)
+            ->setMainImage($media)
+            ->setValidatedAt($validatedAt)
+            ->setPublicationStartsAt($publicationStartsAt)
+            ->setPublicationEndsAt($publicationEndsAt)
+            ->setCreatedAt($createdAt)
+            ->setUpdatedAt($updatedAt);
+
+        $this->assertEquals(1, $article->getId());
+        $this->assertEquals('Title', $article->getTitle());
+        $this->assertEquals('Abstract', $article->getAbstract());
+        $this->assertEquals('Subtitle', $article->getSubtitle());
+        $this->assertEquals(1, $article->getStatus());
+        $this->assertEquals($tags, $article->getTags());
+        $this->assertSame($categories, $article->getCategories());
+        $this->assertSame($media, $article->getMainImage());
+        $this->assertSame($validatedAt, $article->getValidatedAt());
+        $this->assertSame($publicationStartsAt, $article->getPublicationStartsAt());
+        $this->assertSame($publicationEndsAt, $article->getPublicationEndsAt());
+        $this->assertSame($createdAt, $article->getCreatedAt());
+        $this->assertSame($updatedAt, $article->getUpdatedAt());
+        $this->assertEquals('Title', $article->__toString());
+    }
+
+    public function testFragments(): void
+    {
+        $article = new MockArticle();
+        $collection = $article->getFragments();
+
+        $fragmentFoo = $this->createMock(AbstractFragment::class);
+        $fragmentBar = $this->createMock(AbstractFragment::class);
+
+        $newCollection = new ArrayCollection([$fragmentFoo, $fragmentBar]);
+        $article->setFragments($newCollection);
+
+        $this->assertSame($collection, $article->getFragments());
+        $this->assertEquals(2, $collection->count());
+    }
+
+    public function testFragmentAddRemove(): void
+    {
+        $article = new MockArticle();
+        $collection = $article->getFragments();
+
+        $fragment = $this->createMock(AbstractFragment::class);
+        $fragment->expects($this->exactly(2))
+            ->method('setArticle')
+            ->withConsecutive([$article], [null]);
+
+        $article->addFragment($fragment);
+
+        $this->assertEquals(1, $collection->count());
+
+        $article->removeFragment($fragment);
+
+        $this->assertEquals(0, $collection->count());
+    }
+
+    public function testValidatorMetadata(): void
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata->expects($this->once())
+            ->method('addConstraint')
+            ->with($this->callback(function ($parameter) {
+                $this->assertInstanceOf(Callback::class, $parameter);
+                $this->assertEquals([AbstractArticle::class, 'validatorPublicationEnds'], $parameter->callback);
+
+                return true;
+            }));
+
+        AbstractArticle::loadValidatorMetadata($classMetadata);
+    }
+
+    /**
+     * @dataProvider validatorPublicationProvider
+     */
+    public function testValidatorPublication($startAt, $endsAt, $expectation): void
+    {
+        $constraintBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $constraintBuilder->expects($this->$expectation())
+            ->method('addViolation');
+
+        $executionContext = $this->createMock(ExecutionContextInterface::class);
+        $executionContext->expects($this->$expectation())
+            ->method('buildViolation')
+            ->with('article.publication_start_date_before_end_date')
+            ->willReturn($constraintBuilder);
+
+        $article = new MockArticle();
+        $article->setPublicationStartsAt($startAt);
+        $article->setPublicationEndsAt($endsAt);
+
+        AbstractArticle::validatorPublicationEnds($article, $executionContext);
+    }
+
+    public function validatorPublicationProvider()
+    {
+        return [
+            [null, null, 'never'],
+            [null, new \DateTime('2018-07-02 00:00:00'), 'never'],
+            [new \DateTime('2018-07-01 00:00:00'), null, 'never'],
+            [new \DateTime('2018-07-01 00:00:00'), new \DateTime('2018-07-02 00:00:00'), 'never'],
+            [new \DateTime('2018-07-01 00:00:00'), new \DateTime('2018-07-01 00:00:00'), 'once'],
+            [new \DateTime('2018-07-02 00:00:00'), new \DateTime('2018-07-01 00:00:00'), 'once'],
+        ];
+    }
+}
+
+class MockArticle extends AbstractArticle
+{
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Model/AbstractFragmentTest.php
+++ b/tests/Model/AbstractFragmentTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\ArticleBundle\Model\AbstractFragment;
+use Sonata\ArticleBundle\Model\ArticleFragmentInterface;
+use Sonata\ArticleBundle\Model\ArticleInterface;
+use Sonata\ArticleBundle\Model\FragmentInterface;
+
+/**
+ * @author Romain Mouillard <romain.mouillard@gmail.com>
+ */
+class AbstractFragmentTest extends TestCase
+{
+    public function testAbstractFragment(): void
+    {
+        $fragment = new MockFragment();
+
+        $this->assertInstanceOf(FragmentInterface::class, $fragment);
+        $this->assertInstanceOf(ArticleFragmentInterface::class, $fragment);
+        $this->assertTrue($fragment->getEnabled());
+    }
+
+    public function testProperties(): void
+    {
+        $fragment = new MockFragment();
+
+        $article = $this->createMock(ArticleInterface::class);
+        $createdAt = new \DateTime();
+        $updatedAt = new \DateTime();
+
+        $fragment
+            ->setId(1)
+            ->setType('foo')
+            ->setBackofficeTitle('Foo Fragment')
+            ->setEnabled(false)
+            ->setPosition(1)
+            ->setArticle($article)
+            ->setSettings(['foo'])
+            ->setCreatedAt($createdAt)
+            ->setUpdatedAt($updatedAt);
+
+        $this->assertEquals(1, $fragment->getId());
+        $this->assertEquals('foo', $fragment->getType());
+        $this->assertEquals('Foo Fragment', $fragment->getBackofficeTitle());
+        $this->assertFalse($fragment->getEnabled());
+        $this->assertEquals(1, $fragment->getPosition());
+        $this->assertEquals(['foo'], $fragment->getSettings());
+        $this->assertSame($article, $fragment->getArticle());
+        $this->assertSame($createdAt, $fragment->getCreatedAt());
+        $this->assertSame($updatedAt, $fragment->getUpdatedAt());
+        $this->assertEquals('Foo Fragment', $fragment->__toString());
+    }
+
+    public function testSettings(): void
+    {
+        $fragment = new MockFragment();
+
+        $fragment->setSetting('foo', 'bar');
+
+        $this->assertEquals(['foo' => 'bar'], $fragment->getSettings());
+        $this->assertEquals('bar', $fragment->getSetting('foo'));
+        $this->assertNull($fragment->getSetting('undefined'));
+        $this->assertEquals('baz', $fragment->getSetting('undefined-with-default', 'baz'));
+    }
+}
+
+class MockFragment extends AbstractFragment
+{
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because this is the only one.


## Changelog
```markdown
### Added
- Added unit tests on models and entities

### Changed
- Use a `MediaInterface` instead of `Media` in `Article` interface
```

## Subject

This PR adds unit tests on models and entities.
