### PR TITLE
fix(deprecated): fix sf4 deprecations

### DIFF
--- a/src/Model/AbstractArticle.php
+++ b/src/Model/AbstractArticle.php
@@ -61,12 +61,12 @@ abstract class AbstractArticle implements ArticleInterface
     protected $title;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $subtitle;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $abstract;
 
@@ -137,12 +137,12 @@ abstract class AbstractArticle implements ArticleInterface
         return array_keys(self::getStatuses());
     }
 
-    public function setAbstract(string $abstract): void
+    public function setAbstract(?string $abstract): void
     {
         $this->abstract = $abstract;
     }
 
-    public function getAbstract(): string
+    public function getAbstract(): ?string
     {
         return $this->abstract;
     }
@@ -240,12 +240,12 @@ abstract class AbstractArticle implements ArticleInterface
         return $this->status;
     }
 
-    public function setSubtitle(string $subtitle): void
+    public function setSubtitle(?string $subtitle): void
     {
         $this->subtitle = $subtitle;
     }
 
-    public function getSubtitle(): string
+    public function getSubtitle(): ?string
     {
         return $this->subtitle;
     }
@@ -267,7 +267,7 @@ abstract class AbstractArticle implements ArticleInterface
 
     public function getTitle(): string
     {
-        return $this->title;
+        return $this->title ?: '';
     }
 
     public function setUpdatedAt(\DateTimeInterface $updatedAt): void

--- a/src/Model/AbstractFragment.php
+++ b/src/Model/AbstractFragment.php
@@ -44,7 +44,7 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
     protected $fields = [];
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $position;
 
@@ -93,12 +93,12 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
         return $this->enabled;
     }
 
-    public function setPosition(int $position): void
+    public function setPosition(?int $position): void
     {
         $this->position = $position;
     }
 
-    public function getPosition(): int
+    public function getPosition(): ?int
     {
         return $this->position;
     }
@@ -145,7 +145,7 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
 
     public function getBackofficeTitle(): string
     {
-        return $this->backofficeTitle;
+        return $this->backofficeTitle ?: '';
     }
 
     public function setBackofficeTitle(string $backofficeTitle): void

--- a/src/Model/ArticleInterface.php
+++ b/src/Model/ArticleInterface.php
@@ -35,7 +35,7 @@ interface ArticleInterface
 
     public function setAbstract(string $abstract): void;
 
-    public function getAbstract(): string;
+    public function getAbstract(): ?string;
 
     /**
      * @param Category[]|Collection $categories
@@ -83,7 +83,7 @@ interface ArticleInterface
 
     public function setSubtitle(string $subtitle): void;
 
-    public function getSubtitle(): string;
+    public function getSubtitle(): ?string;
 
     /**
      * @param Tag[]|Collection $tags

--- a/src/Model/FragmentInterface.php
+++ b/src/Model/FragmentInterface.php
@@ -60,9 +60,9 @@ interface FragmentInterface
      */
     public function getField(string $name, $default = null);
 
-    public function setPosition(int $position): void;
+    public function setPosition(?int $position): void;
 
-    public function getPosition(): int;
+    public function getPosition(): ?int;
 
     public function getBackofficeTitle(): string;
 

--- a/src/Resources/config/doctrine/AbstractFragment.orm.xml
+++ b/src/Resources/config/doctrine/AbstractFragment.orm.xml
@@ -3,7 +3,7 @@
     <mapped-superclass name="Sonata\ArticleBundle\Entity\AbstractFragment">
         <field name="backofficeTitle" type="string" column="backoffice_title" length="255"/>
         <field name="position" type="integer" column="position" nullable="true"/>
-        <field name="settings" type="json" column="settings"/>
+        <field name="fields" type="json" column="settings"/>
         <field name="type" type="string" column="type" length="64"/>
         <field name="enabled" type="boolean" column="enabled" nullable="false"/>
         <field name="createdAt" type="datetime" column="created_at"/>

--- a/tests/Admin/ArticleAdminTest.php
+++ b/tests/Admin/ArticleAdminTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ArticleBundle\Tests\Admin;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Controller\CRUDController;
+use Sonata\ArticleBundle\Admin\ArticleAdmin;
+use Sonata\ArticleBundle\Entity\AbstractArticle;
+
+class ArticleAdminTest extends TestCase
+{
+    public function testToString(): void
+    {
+        $articleAdmin = new ArticleAdmin(
+            'admin.article',
+            AbstractArticle::class,
+            CRUDController::class,
+            AbstractFragment::class,
+            20
+        );
+        /** @var AbstractArticle|MockObject $article */
+        $article = $this->getMockForAbstractClass(AbstractArticle::class);
+
+        $article->setTitle('short title');
+        $this->assertSame('short title', $articleAdmin->toString($article));
+
+        $article->setTitle('longer than 20 chars with breakpoint');
+        $this->assertSame('longer than 20 chars...', $articleAdmin->toString($article));
+
+        $article->setTitle('longer than 20 charnobreakpoint');
+        $this->assertSame('longer than 20 charnobreakpoint', $articleAdmin->toString($article));
+    }
+}


### PR DESCRIPTION
### Fixed
Fix the following Symfony4 deprecations:
- cascade_validation
- choices_as_value

AbstractArticle
- Fix default scalar values to match new return types

AbstractFragment
- Fix unknown field `settings` in AbstractFragment doctrine configuration
- Fix default scalar values to match new return types

ArticleAdmin
- Fix chained fragment setters call to match the removal of the fluent interface

## Changelog
```markdown
### Fixed
- deprecations related to `cascade_validation` and `choices_as_value` form options
```