### PR TITLE
Bump branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.x-dev"
+            "dev-master": "1.x-dev"
         }
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
Please just approve. The first commit bumps to 1, and will be the starting point for the new 1.x branch. The second commit bumps to 2.
Note that only the branch-alias ending up on master will ever be taken into account, the one on 1.x is here for nothing… it should have been 1.x from the start I think.