### PR TITLE
fix(article): fix article validatedAt typehint

### DIFF
--- a/src/Model/AbstractArticle.php
+++ b/src/Model/AbstractArticle.php
@@ -285,9 +285,14 @@ abstract class AbstractArticle implements ArticleInterface
         $this->validatedAt = $validatedAt;
     }
 
-    public function getValidatedAt(): \DateTimeInterface
+    public function getValidatedAt(): ?\DateTimeInterface
     {
         return $this->validatedAt;
+    }
+
+    public function isValidated(): bool
+    {
+        return null !== $this->validatedAt;
     }
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void

--- a/src/Model/ArticleInterface.php
+++ b/src/Model/ArticleInterface.php
@@ -105,5 +105,5 @@ interface ArticleInterface
 
     public function setValidatedAt(\DateTimeInterface $validatedAt = null): void;
 
-    public function getValidatedAt(): \DateTimeInterface;
+    public function getValidatedAt(): ?\DateTimeInterface;
 }

--- a/tests/Model/AbstractArticleTest.php
+++ b/tests/Model/AbstractArticleTest.php
@@ -106,6 +106,15 @@ class AbstractArticleTest extends TestCase
         $this->assertEquals('Title', $article->__toString());
     }
 
+    public function testIsValidated(): void
+    {
+        $article = new MockArticle();
+        $this->assertFalse($article->isValidated());
+
+        $article->setValidatedAt(new \DateTime());
+        $this->assertTrue($article->isValidated());
+    }
+
     public function testFragments(): void
     {
         $article = new MockArticle();


### PR DESCRIPTION
I am targeting this branch, because this is a major fix. The type hint change is **not BC** but without it we have a strong inconsistency in allowed values of `Article::$validatedAt` property.

## Changelog

```markdown
### Added
- Added `Article::isValidated()` method

### Fixed
- Fixed `Article::getValidatedAt()` to be able to return null
```

## Subject

The `Article::getValidatedAt()` is not allowing a null return while the `$validatedAt` property can be set to null by default of by the setter. I have also added the `Article::isValidated()` helper method to implement a common usage of this property.

**The type hint change is not BC but without it we have a strong inconsistency in allowed values of Article::$validatedAt property.**

Is it ok for you to fix it in 1.x ?

cc @nanofelis 