### PR TITLE
Remove useless backslash

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('sonata_article');
 
         // Keep compatibility with symfony/config < 4.2
-        if (!\method_exists($treeBuilder, 'getRootNode')) {
+        if (!method_exists($treeBuilder, 'getRootNode')) {
             $node = $treeBuilder->root('sonata_article')->children();
         } else {
             $node = $treeBuilder->getRootNode()->children();


### PR DESCRIPTION
This function is not in the whitelist of functions benefiting from it.
See https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/6f2c266440de15e23a82788e598ea66521ed60b2/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php#L338

This fixes the build.
