### PR TITLE
Fix Article and Fragment interfaces return types

### DIFF
--- a/src/Model/AbstractArticle.php
+++ b/src/Model/AbstractArticle.php
@@ -91,7 +91,7 @@ abstract class AbstractArticle implements ArticleInterface
     protected $tags;
 
     /**
-     * @var MediaInterface
+     * @var MediaInterface|null
      */
     protected $mainImage;
 
@@ -172,7 +172,7 @@ abstract class AbstractArticle implements ArticleInterface
         $this->mainImage = $mainImage;
     }
 
-    public function getMainImage(): MediaInterface
+    public function getMainImage(): ?MediaInterface
     {
         return $this->mainImage;
     }

--- a/src/Model/AbstractFragment.php
+++ b/src/Model/AbstractFragment.php
@@ -54,7 +54,7 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
     protected $backofficeTitle;
 
     /**
-     * @var ArticleInterface
+     * @var ArticleInterface|null
      */
     protected $article;
 
@@ -68,7 +68,7 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
         $this->article = $article;
     }
 
-    public function getArticle(): ArticleInterface
+    public function getArticle(): ?ArticleInterface
     {
         return $this->article;
     }
@@ -128,7 +128,7 @@ abstract class AbstractFragment implements FragmentInterface, ArticleFragmentInt
         $this->type = $type;
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->type;
     }

--- a/src/Model/ArticleFragmentInterface.php
+++ b/src/Model/ArticleFragmentInterface.php
@@ -18,7 +18,7 @@ namespace Sonata\ArticleBundle\Model;
  */
 interface ArticleFragmentInterface
 {
-    public function getArticle(): ArticleInterface;
+    public function getArticle(): ?ArticleInterface;
 
     public function setArticle(?ArticleInterface $article = null): void;
 }

--- a/src/Model/ArticleInterface.php
+++ b/src/Model/ArticleInterface.php
@@ -53,7 +53,7 @@ interface ArticleInterface
 
     public function setMainImage(MediaInterface $mainImage = null): void;
 
-    public function getMainImage(): MediaInterface;
+    public function getMainImage(): ?MediaInterface;
 
     public function addFragment(FragmentInterface $fragment): void;
 

--- a/src/Model/FragmentInterface.php
+++ b/src/Model/FragmentInterface.php
@@ -42,7 +42,7 @@ interface FragmentInterface
 
     public function setType(string $type): void;
 
-    public function getType(): string;
+    public function getType(): ?string;
 
     public function setFields(array $settings): void;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because this is a backward compatible fix (interfaces made less restrictive).

Articles and Fragments interfaces has too restrictive return types which does not include null in most of the case. This PR is making return types less restrictive to allow values to be null. 

Behind the scene, I think there was a confusion between what can be null for these entities in database (some fields not nullable), and can be null in an object point of view. In the later, every field which does not start with a default value and/or have a setter allowing null can potentially have a null value.

## Changelog

```markdown
### Changed
- Changed `ArticleInterface`, `FragmentInterface` and `ArticleFragmentInterface` to allow null return types.
```

