### PR TITLE
Fix column fields for fragment entity

### DIFF
--- a/src/Resources/config/doctrine/AbstractFragment.orm.xml
+++ b/src/Resources/config/doctrine/AbstractFragment.orm.xml
@@ -3,7 +3,7 @@
     <mapped-superclass name="Sonata\ArticleBundle\Entity\AbstractFragment">
         <field name="backofficeTitle" type="string" column="backoffice_title" length="255"/>
         <field name="position" type="integer" column="position" nullable="true"/>
-        <field name="fields" type="json" column="settings"/>
+        <field name="fields" type="json" column="fields"/>
         <field name="type" type="string" column="type" length="64"/>
         <field name="enabled" type="boolean" column="enabled" nullable="false"/>
         <field name="createdAt" type="datetime" column="created_at"/>


### PR DESCRIPTION
## Subject

The goal of this PR is to fix the column mapped to the field `fields` in doctrine.
I think it's because before it was called `settings` and we forget to change it.

## Changelog

```markdown
### Changed
- Column used for Fragment entity `fields`
```