### PR TITLE
Allow undo of article fragment remove

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,4 +12,5 @@ Article Bundle
    reference/getting_started
    reference/configuration
    reference/custom_fragment
+   reference/delete_fragment
    reference/todo

--- a/docs/reference/delete_fragment.rst
+++ b/docs/reference/delete_fragment.rst
@@ -1,0 +1,8 @@
+Article's Fragment
+==================
+
+This feature moves the removed fragment inputs in another DOM and thereafter
+this allows the cancellations of removed fragments.
+After the deletion of a fragment, each deleted fragment item in the fragment list
+contains a reset button (to undo the deletion) and the fragment title. This action triggers undo of
+the deletion of the fragment so the deleted fragment inputs (and elements) are moved to their original place.

--- a/src/Admin/FragmentAdmin.php
+++ b/src/Admin/FragmentAdmin.php
@@ -213,7 +213,7 @@ final class FragmentAdmin extends AbstractAdmin
      */
     protected function getService(string $type): FragmentServiceInterface
     {
-        if (!array_key_exists($type, $this->fragmentServices)) {
+        if (!\array_key_exists($type, $this->fragmentServices)) {
             throw new \RuntimeException(sprintf('Fragment service for type `%s` is not handled by this admin', $type));
         }
 

--- a/src/Helper/FragmentHelper.php
+++ b/src/Helper/FragmentHelper.php
@@ -58,7 +58,7 @@ class FragmentHelper
     {
         $type = $fragment->getType();
 
-        if (!array_key_exists($type, $this->fragmentServices)) {
+        if (!\array_key_exists($type, $this->fragmentServices)) {
             throw new \RuntimeException(sprintf('Cannot render Fragment of type `%s`. Service not found.', $type));
         }
 

--- a/tests/Helper/FragmentHelperTest.php
+++ b/tests/Helper/FragmentHelperTest.php
@@ -63,12 +63,12 @@ class FragmentHelperTest extends TestCase
         $fragment = $this->getFragmentMock();
 
         // templating render must be called once
-        $this->templating->expects($this->once())->method('render')->will($this->returnValue('foo'));
+        $this->templating->expects($this->once())->method('render')->willReturn('foo');
 
         $fragmentService = $this->createMock([FragmentServiceInterface::class, ExtraContentProviderInterface::class]);
 
-        $fragmentService->expects($this->once())->method('getTemplate')->will($this->returnValue('template.html.twig'));
-        $fragmentService->expects($this->once())->method('getExtraContent')->will($this->returnValue(['foo' => 'bar']));
+        $fragmentService->expects($this->once())->method('getTemplate')->willReturn('template.html.twig');
+        $fragmentService->expects($this->once())->method('getExtraContent')->willReturn(['foo' => 'bar']);
 
         $this->fragmentHelper->setFragmentServices(['foo.bar' => $fragmentService]);
         $this->fragmentHelper->render($fragment);
@@ -83,8 +83,8 @@ class FragmentHelperTest extends TestCase
     private function getFragmentMock(): MockObject
     {
         $fragment = $this->createMock(FragmentInterface::class);
-        $fragment->expects($this->once())->method('getType')->will($this->returnValue('foo.bar'));
-        $fragment->expects($this->any())->method('getFields')->will($this->returnValue([]));
+        $fragment->expects($this->once())->method('getType')->willReturn('foo.bar');
+        $fragment->expects($this->any())->method('getFields')->willReturn([]);
 
         return $fragment;
     }

--- a/tests/Twig/FragmentExtensionTest.php
+++ b/tests/Twig/FragmentExtensionTest.php
@@ -81,7 +81,7 @@ class FragmentExtensionTest extends TestCase
         $article = $this->createMock(ArticleInterface::class);
         $article->expects($this->any())
             ->method('getFragments')
-            ->will($this->returnValue($fragments));
+            ->willReturn($fragments);
 
         // we expect only two calls
         $this->fragmentHelper->expects($this->at(0))
@@ -109,10 +109,10 @@ class FragmentExtensionTest extends TestCase
         $fragment = $this->createMock(FragmentInterface::class);
         $fragment->expects($this->any())
             ->method('getFields')
-            ->will($this->returnValue($settings));
+            ->willReturn($settings);
         $fragment->expects($this->any())
             ->method('getEnabled')
-            ->will($this->returnValue($enabled));
+            ->willReturn($enabled);
 
         return $fragment;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because i propose a new article fragments deletion feature. This feature  move the removed fragment input's in another dom and this allows the cancellations of removed fragments. 

This feature fix too a bug of the removal of predefined fragments in the creation of new article. Bug detected at Ekino.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added to fragmentList.jquery.js `moveSelectedFragmentOutsideOfForm()` to move selected fragment in tmp dom
- Added to fragmentList.jquery.js `cancelFragmentDeletion()`  to cancel the fragment deletion

### Changed
The 'removed' fragments are not removed completely just moved in another dom, 
which allows the cancellation. 
         
```
![](https://user-images.githubusercontent.com/26876221/52793128-49d86e00-306d-11e9-83bc-b05df828ee21.gif)
<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
