### PR TITLE
Add translator to AbstractFragmentService

### DIFF
--- a/src/Admin/FragmentAdmin.php
+++ b/src/Admin/FragmentAdmin.php
@@ -213,7 +213,7 @@ final class FragmentAdmin extends AbstractAdmin
      */
     protected function getService(string $type): FragmentServiceInterface
     {
-        if (!array_key_exists($type, $this->fragmentServices)) {
+        if (!\array_key_exists($type, $this->fragmentServices)) {
             throw new \RuntimeException(sprintf('Fragment service for type `%s` is not handled by this admin', $type));
         }
 

--- a/src/Helper/FragmentHelper.php
+++ b/src/Helper/FragmentHelper.php
@@ -58,7 +58,7 @@ class FragmentHelper
     {
         $type = $fragment->getType();
 
-        if (!array_key_exists($type, $this->fragmentServices)) {
+        if (!\array_key_exists($type, $this->fragmentServices)) {
             throw new \RuntimeException(sprintf('Cannot render Fragment of type `%s`. Service not found.', $type));
         }
 

--- a/src/Resources/translations/SonataArticleBundle.hu.xliff
+++ b/src/Resources/translations/SonataArticleBundle.hu.xliff
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hu" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="article">
+                <source>article</source>
+                <target>Cikk</target>
+            </trans-unit>
+            <trans-unit id="fragment">
+                <source>fragment</source>
+                <target>Részlet</target>
+            </trans-unit>
+            <trans-unit id="close">
+                <source>close</source>
+                <target>Bezárás</target>
+            </trans-unit>
+            <trans-unit id="delete">
+                <source>delete</source>
+                <target>Törlés</target>
+            </trans-unit>
+            <trans-unit id="status">
+                <source>status</source>
+                <target>Státusz</target>
+            </trans-unit>
+            <trans-unit id="actions">
+                <source>actions</source>
+                <target>Műveletek</target>
+            </trans-unit>
+            <trans-unit id="new.fragment">
+                <source>new.fragment</source>
+                <target>Új részlet</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_article_list">
+                <source>breadcrumb.link_article_list</source>
+                <target>Cikkek</target>
+            </trans-unit>
+            <trans-unit id="list.label_title">
+                <source>list.label_title</source>
+                <target>Cím</target>
+            </trans-unit>
+            <trans-unit id="list.label_updated_at">
+                <source>list.label_updated_at</source>
+                <target>Frissítve</target>
+            </trans-unit>
+            <trans-unit id="list.label_status">
+                <source>list.label_status</source>
+                <target>Státusz</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>Cím</target>
+            </trans-unit>
+            <trans-unit id="form.label_subtitle">
+                <source>form.label_subtitle</source>
+                <target>Felirat</target>
+            </trans-unit>
+            <trans-unit id="form.label_abstract">
+                <source>form.label_abstract</source>
+                <target>Összegzés</target>
+            </trans-unit>
+            <trans-unit id="form.label_status">
+                <source>form.label_status</source>
+                <target>Státusz</target>
+            </trans-unit>
+            <trans-unit id="form.label_publication_starts_at">
+                <source>form.label_publication_starts_at</source>
+                <target>A publikáció dátuma</target>
+            </trans-unit>
+            <trans-unit id="form.label_publication_ends_at">
+                <source>form.label_publication_ends_at</source>
+                <target>A publikáció visszavonásának dátuma</target>
+            </trans-unit>
+            <trans-unit id="form.label_backoffice_title">
+                <source>form.label_backoffice_title</source>
+                <target>Backoffice cím</target>
+            </trans-unit>
+            <trans-unit id="remove_confirm">
+                <source>remove_confirm</source>
+                <target>A frissítést követően a részlet törlésre kerül. Biztos ebben ?</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Resources/views/FragmentAdmin/edit_collection_fragment.html.twig
+++ b/src/Resources/views/FragmentAdmin/edit_collection_fragment.html.twig
@@ -19,7 +19,7 @@
                                 remove_confirm: 'remove_confirm'|trans({}, 'SonataArticleBundle')
                             }|json_encode }}">
                         {% for fragServId, fragServ in sonata_admin.field_description.associationadmin.fragmentServices %}
-                        <option value="{{ fragServId }}">{{ fragServ.name }}</option>
+                        <option value="{{ fragServId }}">{{ fragServ.name|trans({}, 'SonataArticleBundle') }}</option>
                         {% endfor %}
                     </select>
                     <button type="button" id="field_actions_{{ id }}" class="fragmentCreator__button fa fa-plus-square-o"></button>

--- a/src/Resources/views/FragmentAdmin/form.html.twig
+++ b/src/Resources/views/FragmentAdmin/form.html.twig
@@ -1,14 +1,15 @@
 {% block form %}
-    {% set fragmentName = admin.fragmentServices[form.vars.data.type].name %}
+    {% set fragmentName = admin.fragmentServices[form.vars.data.type].name|trans({}, 'SonataArticleBundle') %}
+    {% set fragmentLabel = {{ 'fragment'|trans({}, 'SonataArticleBundle') }} %}
     <div data-fragment-form="{{ form.vars.id }}"
          data-form-tmp="true"
-         data-formdata='{ "name": "Fragment {{ fragmentName }}", "type": "{{ form.vars.data.backofficeTitle }}" }'
+         data-formdata='{ "name": "{{ fragmentLabel }} {{ fragmentName|escape }}", "type": "{{ form.vars.data.backofficeTitle|trans({}, 'SonataArticleBundle') }}" }'
          data-errors="{{ form.vars.errors|length }}">
         <div class="col-md-12">
             <div class="box box-primary">
                 <div class="box-header">
                     <h4 class="box-title">
-                        {{ 'fragment'|trans({}, 'SonataArticleBundle') }} {{ fragmentName }}
+                        {{ fragmentLabel }} {{ fragmentName }}
                     </h4>
                 </div>
                 <div class="box-body">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because i want to translate fragment's name. And add Hungarian translation file.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add **|trans()** in the follow twig files: "edit_collection_fragment.html.twig" 
  and "form.html.twig" to translate the fragment name.
- Add Hungarian translation file "SonataArticleBundle.hu.xliff"
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
