### PR TITLE
Translations of fragments

### DIFF
--- a/src/Resources/views/FragmentAdmin/edit_collection_fragment.html.twig
+++ b/src/Resources/views/FragmentAdmin/edit_collection_fragment.html.twig
@@ -19,7 +19,7 @@
                                 remove_confirm: 'remove_confirm'|trans({}, 'SonataArticleBundle')
                             }|json_encode }}">
                         {% for fragServId, fragServ in sonata_admin.field_description.associationadmin.fragmentServices %}
-                        <option value="{{ fragServId }}">{{ fragServ.name }}</option>
+                        <option value="{{ fragServId }}">{{ fragServ.name|trans({}, 'SonataArticleBundle')  }}</option>
                         {% endfor %}
                     </select>
                     <button type="button" id="field_actions_{{ id }}" class="fragmentCreator__button fa fa-plus-square-o"></button>

--- a/src/Resources/views/FragmentAdmin/form.html.twig
+++ b/src/Resources/views/FragmentAdmin/form.html.twig
@@ -2,13 +2,13 @@
     {% set fragmentName = admin.fragmentServices[form.vars.data.type].name %}
     <div data-fragment-form="{{ form.vars.id }}"
          data-form-tmp="true"
-         data-formdata='{ "name": "Fragment {{ fragmentName }}", "type": "{{ form.vars.data.backofficeTitle }}" }'
+         data-formdata='{ "name": "Fragment {{ fragmentName|trans({}, 'SonataArticleBundle')  }}", "type": "{{ form.vars.data.backofficeTitle }}" }'
          data-errors="{{ form.vars.errors|length }}">
         <div class="col-md-12">
             <div class="box box-primary">
                 <div class="box-header">
                     <h4 class="box-title">
-                        {{ 'fragment'|trans({}, 'SonataArticleBundle') }} {{ fragmentName }}
+                        {{ 'fragment'|trans({}, 'SonataArticleBundle') }} {{ fragmentName|trans({}, 'SonataArticleBundle')  }}
                     </h4>
                 </div>
                 <div class="box-body">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, to add translation for the articles fragments.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
Add translation for the fragments name in :
  - FragmentAdmin/edit_collection_fragment.html.twig
  - FragmentAdmin/form.html.twig
