### PR TITLE
Fix fragment form bug

### DIFF
--- a/src/Resources/views/FragmentAdmin/form.html.twig
+++ b/src/Resources/views/FragmentAdmin/form.html.twig
@@ -1,6 +1,6 @@
 {% block form %}
     {% set fragmentName = admin.fragmentServices[form.vars.data.type].name|trans({}, 'SonataArticleBundle') %}
-    {% set fragmentLabel = {{ 'fragment'|trans({}, 'SonataArticleBundle') }} %}
+    {% set fragmentLabel = 'fragment'|trans({}, 'SonataArticleBundle') %}
     <div data-fragment-form="{{ form.vars.id }}"
          data-form-tmp="true"
          data-formdata='{ "name": "{{ fragmentLabel }} {{ fragmentName|escape }}", "type": "{{ form.vars.data.backofficeTitle|trans({}, 'SonataArticleBundle') }}" }'

--- a/tests/Helper/FragmentHelperTest.php
+++ b/tests/Helper/FragmentHelperTest.php
@@ -63,12 +63,12 @@ class FragmentHelperTest extends TestCase
         $fragment = $this->getFragmentMock();
 
         // templating render must be called once
-        $this->templating->expects($this->once())->method('render')->will($this->returnValue('foo'));
+        $this->templating->expects($this->once())->method('render')->willReturn('foo');
 
         $fragmentService = $this->createMock([FragmentServiceInterface::class, ExtraContentProviderInterface::class]);
 
-        $fragmentService->expects($this->once())->method('getTemplate')->will($this->returnValue('template.html.twig'));
-        $fragmentService->expects($this->once())->method('getExtraContent')->will($this->returnValue(['foo' => 'bar']));
+        $fragmentService->expects($this->once())->method('getTemplate')->willReturn('template.html.twig');
+        $fragmentService->expects($this->once())->method('getExtraContent')->willReturn(['foo' => 'bar']);
 
         $this->fragmentHelper->setFragmentServices(['foo.bar' => $fragmentService]);
         $this->fragmentHelper->render($fragment);
@@ -83,8 +83,8 @@ class FragmentHelperTest extends TestCase
     private function getFragmentMock(): MockObject
     {
         $fragment = $this->createMock(FragmentInterface::class);
-        $fragment->expects($this->once())->method('getType')->will($this->returnValue('foo.bar'));
-        $fragment->expects($this->any())->method('getFields')->will($this->returnValue([]));
+        $fragment->expects($this->once())->method('getType')->willReturn('foo.bar');
+        $fragment->expects($this->any())->method('getFields')->willReturn([]);
 
         return $fragment;
     }

--- a/tests/Twig/FragmentExtensionTest.php
+++ b/tests/Twig/FragmentExtensionTest.php
@@ -81,7 +81,7 @@ class FragmentExtensionTest extends TestCase
         $article = $this->createMock(ArticleInterface::class);
         $article->expects($this->any())
             ->method('getFragments')
-            ->will($this->returnValue($fragments));
+            ->willReturn($fragments);
 
         // we expect only two calls
         $this->fragmentHelper->expects($this->at(0))
@@ -109,10 +109,10 @@ class FragmentExtensionTest extends TestCase
         $fragment = $this->createMock(FragmentInterface::class);
         $fragment->expects($this->any())
             ->method('getFields')
-            ->will($this->returnValue($settings));
+            ->willReturn($settings);
         $fragment->expects($this->any())
             ->method('getEnabled')
-            ->will($this->returnValue($enabled));
+            ->willReturn($enabled);
 
         return $fragment;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, to fix fragment form bug

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
Fix bug here in this file: FragmentAdmin/form.html.twig

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
![screenshot-backoffice-creative canalplus localdev-2019 05 28-16-09-32](https://user-images.githubusercontent.com/26876221/58484929-59cf1600-8163-11e9-95d9-2a3fe5bffa10.png)
