### PR TITLE
Better fragment data formatter

### DIFF
--- a/src/Resources/views/FragmentAdmin/form.html.twig
+++ b/src/Resources/views/FragmentAdmin/form.html.twig
@@ -1,10 +1,12 @@
 {% block form %}
     {% set fragmentName = admin.fragmentServices[form.vars.data.type].name|trans({}, 'SonataArticleBundle') %}
     {% set fragmentLabel = 'fragment'|trans({}, 'SonataArticleBundle') %}
-    {% set formdata = {'name': fragmentLabel ~ ' ' ~ fragmentName|escape, 'type' : form.vars.data.backofficeTitle|trans({}, 'SonataArticleBundle') } %}
     <div data-fragment-form="{{ form.vars.id }}"
          data-form-tmp="true"
-         data-formdata="{{ formdata|json_encode() }}"
+         data-formdata="{{ {
+             'name': fragmentLabel ~ ' ' ~ fragmentName|escape, 
+             'type' : form.vars.data.backofficeTitle|trans({}, 'SonataArticleBundle') 
+         }|json_encode() }}"
          data-errors="{{ form.vars.errors|length }}">
         <div class="col-md-12">
             <div class="box box-primary">

--- a/src/Resources/views/FragmentAdmin/form.html.twig
+++ b/src/Resources/views/FragmentAdmin/form.html.twig
@@ -1,9 +1,10 @@
 {% block form %}
     {% set fragmentName = admin.fragmentServices[form.vars.data.type].name|trans({}, 'SonataArticleBundle') %}
     {% set fragmentLabel = 'fragment'|trans({}, 'SonataArticleBundle') %}
+    {% set formdata = {'name': fragmentLabel ~ ' ' ~ fragmentName|escape, 'type' : form.vars.data.backofficeTitle|trans({}, 'SonataArticleBundle') } %}
     <div data-fragment-form="{{ form.vars.id }}"
          data-form-tmp="true"
-         data-formdata='{ "name": "{{ fragmentLabel }} {{ fragmentName|escape }}", "type": "{{ form.vars.data.backofficeTitle|trans({}, 'SonataArticleBundle') }}" }'
+         data-formdata="{{ formdata|json_encode() }}"
          data-errors="{{ form.vars.errors|length }}">
         <div class="col-md-12">
             <div class="box box-primary">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because i have a little problem with the data format passed to the DOM who display the fragment's name and type. The little change format better the data passed to the DOM.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->
<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->
<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
