### PR TITLE
[FEAT] : Overridable edit_collection_fragment template

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -1,8 +1,6 @@
 {% extends '@SonataAdmin/Form/form_admin_fields.html.twig' %}
 
-{% block sonata_admin_collection_fragment %}
-    {% include '@SonataArticle/FragmentAdmin/edit_collection_fragment.html.twig' %}
-{% endblock %}
+{% use '@SonataArticle/FragmentAdmin/edit_collection_fragment.html.twig' %}
 
 {% block sonata_type_collection_widget %}
     {% if sonata_admin.field_description.mappingtype == 4 %}

--- a/src/Resources/views/FragmentAdmin/edit_collection_fragment.html.twig
+++ b/src/Resources/views/FragmentAdmin/edit_collection_fragment.html.twig
@@ -1,55 +1,65 @@
-{% if sonata_admin.field_description.hasassociationadmin %}
-    <div class="field-container row">
-        <div class="col-md-4">
-            <ul class="fragmentList" id="sortable_list_{{ id }}"></ul>
-            {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
-                <label class="control-label">{{ 'new.fragment'|trans({}, 'SonataArticleBundle') }}</label>
-                <div class="fragmentCreator">
-                    <select id="field_actions_select_{{ id }}" class="fragmentCreator__select"
-                            data-href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
-                            data-id="{{ id }}"
-                            data-add-fragment-url="{{ sonata_admin.admin.getConfigurationPool().getAdminByAdminCode('sonata.article.admin.fragment').generateUrl('form', {
-                                'code':      sonata_admin.admin.root.code,
-                                'elementId': id,
-                                'subclass':  sonata_admin.admin.getActiveSubclassCode(),
-                                'objectId':  sonata_admin.admin.root.subject ? sonata_admin.admin.root.id(sonata_admin.admin.root.subject) : false,
-                                'uniqid':    sonata_admin.admin.root.uniqid
-                            } + sonata_admin.field_description.getOption('link_parameters', {})) }}"
-                            data-translations="{{ {
-                                remove_confirm: 'remove_confirm'|trans({}, 'SonataArticleBundle')
-                            }|json_encode }}">
-                        {% for fragServId, fragServ in sonata_admin.field_description.associationadmin.fragmentServices %}
-                        <option value="{{ fragServId }}">{{ fragServ.name|trans({}, 'SonataArticleBundle') }}</option>
-                        {% endfor %}
-                    </select>
-                    <button type="button" id="field_actions_{{ id }}" class="fragmentCreator__button fa fa-plus-square-o"></button>
-                </div>
-                <script type="text/javascript" src="{{ asset('bundles/sonataarticle/js/editOneAssociationFragment.js') }}"></script>
-            {% endif %}
-        </div>
-        <div class="col-md-8">
-            <div class="row">
-                <div id="field_widget_{{ id }}">
-                    {% if form.children|length > 0 %}
-                        {% for child in form.children %}
-                            {{ form_widget(child) }}
-                        {% endfor %}
-                    {% endif %}
+{% block sonata_admin_collection_fragment %}
+    {% if sonata_admin.field_description.hasassociationadmin %}
+        <div class="field-container row">
+            <div class="col-md-4">
+                <ul class="fragmentList" id="sortable_list_{{ id }}"></ul>
+                {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+                    <label class="control-label">{{ 'new.fragment'|trans({}, 'SonataArticleBundle') }}</label>
+                    <div class="fragmentCreator">
+                        {% block sonata_admin_collection_fragment_select %}
+                            <select id="field_actions_select_{{ id }}" class="fragmentCreator__select"
+                                    data-href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
+                                    data-id="{{ id }}"
+                                    data-add-fragment-url="{{ sonata_admin.admin.getConfigurationPool().getAdminByAdminCode('sonata.article.admin.fragment').generateUrl('form', {
+                                        'code':      sonata_admin.admin.root.code,
+                                        'elementId': id,
+                                        'subclass':  sonata_admin.admin.getActiveSubclassCode(),
+                                        'objectId':  sonata_admin.admin.root.subject ? sonata_admin.admin.root.id(sonata_admin.admin.root.subject) : false,
+                                        'uniqid':    sonata_admin.admin.root.uniqid
+                                    } + sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                                    data-translations="{{ {
+                                        remove_confirm: 'remove_confirm'|trans({}, 'SonataArticleBundle')
+                                    }|json_encode }}">
+                                {% block sonata_admin_collection_fragment_select_options %}
+                                    {% for fragServId, fragServ in sonata_admin.field_description.associationadmin.fragmentServices %}
+                                        <option value="{{ fragServId }}">{{ fragServ.name|trans({}, 'SonataArticleBundle') }}</option>
+                                    {% endfor %}
+                                {% endblock %}
+                            </select>
+                        {% endblock %}
+                        <button type="button" id="field_actions_{{ id }}" class="fragmentCreator__button fa fa-plus-square-o"></button>
+                    </div>
+                    <script type="text/javascript" src="{{ asset('bundles/sonataarticle/js/editOneAssociationFragment.js') }}"></script>
+                {% endif %}
+            </div>
+            <div class="col-md-8">
+                <div class="row">
+                    {% block sonata_admin_collection_fragment_field_widget %}
+                        <div id="field_widget_{{ id }}">
+                            {% if form.children|length > 0 %}
+                                {% for child in form.children %}
+                                    {{ form_widget(child) }}
+                                {% endfor %}
+                            {% endif %}
+                        </div>
+                    {% endblock %}
                 </div>
             </div>
         </div>
-    </div>
-    <li class="fragment hide" data-fragment id="fragmentTpl">
-        <div class="fragment__info">
-            <span class="fa fa-pencil fragment__status"></span>
-            <span class="fa fa-check fragment__status"></span>
-            <span class="fa fa-exclamation-circle fragment__status"></span>
-            <div class="fragment__cell">
-                <strong data-name class="fragment__title"></strong>
-                <span data-type class="fragment__desc"></span>
-            </div>
-        </div>
-        <button type="button" data-frag-remove class="fragment__close fa fa-times"></button>
-        <span class="fragment__handle fa fa-arrows"></span>
-    </li>
-{% endif %}
+        {% block sonata_admin_collection_fragment_tpl %}
+            <li class="fragment hide" data-fragment id="fragmentTpl">
+                <div class="fragment__info">
+                    <span class="fa fa-pencil fragment__status"></span>
+                    <span class="fa fa-check fragment__status"></span>
+                    <span class="fa fa-exclamation-circle fragment__status"></span>
+                    <div class="fragment__cell">
+                        <strong data-name class="fragment__title"></strong>
+                        <span data-type class="fragment__desc"></span>
+                    </div>
+                </div>
+                <button type="button" data-frag-remove class="fragment__close fa fa-times"></button>
+                <span class="fragment__handle fa fa-arrows"></span>
+            </li>
+        {% endblock %}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch to surround the different parts of **edit_collection_fragment.html.twig** template with blocks to make it more overridable. 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->




<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
