### PR TITLE
[FIX-BUG] : Fix article fragments reset order bug

### DIFF
--- a/src/Resources/public/js/fragmentList.jquery.js
+++ b/src/Resources/public/js/fragmentList.jquery.js
@@ -308,10 +308,12 @@
 
             this.$list.children('li').each(function(index) {
                 var $this = $(this),
-                    $form = self.getFormByFragmentId($this.data('fragId')),
-                    $positionField = $form.find(self.options.formPositionName);
+                    $form = self.getFormByFragmentId($this.data('fragId'));
 
-                $positionField.val(index);
+                if ($form) {
+                    var $positionField = $form.find(self.options.formPositionName);
+                    $positionField.val(index);
+                }
             });
         },
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, to fix a bug of **resetOrder()** function form  fragmentList.jquery.js. <br />Actually we can cancel the deletion of fragments.<br /> The form of the fragment is moved to another DOM and the  **resetOrder()** function  determine the position of the fragment using the form object.<br /> If we have removed fragments in our list the form object is undefined for those fragments and **resetOrder()** breaks.<br /> This is my proposal to fix this bug. 


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->