### PR TITLE
Remove deprecated phpunit calls

### DIFF
--- a/tests/Twig/FragmentExtensionTest.php
+++ b/tests/Twig/FragmentExtensionTest.php
@@ -37,10 +37,7 @@ class FragmentExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->fragmentHelper = $this->getMockBuilder(FragmentHelper::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['render'])
-            ->getMock();
+        $this->fragmentHelper = $this->createMock(FragmentHelper::class);
 
         $this->fragmentExtension = new FragmentExtension($this->fragmentHelper);
     }
@@ -83,11 +80,7 @@ class FragmentExtensionTest extends TestCase
             ->method('getFragments')
             ->willReturn($fragments);
 
-        // we expect only two calls
-        $this->fragmentHelper->expects($this->at(0))
-            ->method('render')
-            ->willReturnCallback([$this, 'renderFragment']);
-        $this->fragmentHelper->expects($this->at(1))
+        $this->fragmentHelper->expects($this->exactly(2))
             ->method('render')
             ->willReturnCallback([$this, 'renderFragment']);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is pedantic.
